### PR TITLE
Added feature to read page content from stdin.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -186,9 +186,25 @@ gboolean vb_load_uri(const Arg *arg)
         path = GET_CHAR("home-page");
     }
 
-    /* If path contains :// but no space we open it direct. This is required
-     * to use :// also with shortcuts */
-    if ((strstr(path, "://") && !strchr(path, ' ')) || !strncmp(path, "about:", 6)) {
+    if (strcmp(path, "-") == 0) {
+        /* read content from stdin */
+        GIOChannel *ch = g_io_channel_unix_new(fileno(stdin));
+        gchar *buf = NULL; gsize len; GError *err = NULL;
+        g_io_channel_read_to_end(ch, &buf, &len, &err);
+        g_io_channel_unref(ch);
+        if (err) {
+            g_warning("Error loading from stdin: %s\n", err->message);
+            g_error_free(err);
+            g_free(buf);
+        } else {
+            webkit_web_view_load_string(
+                vb.gui.webview, buf, "text/html", NULL, "(stdin)");
+            g_free(buf);
+            return true;
+        }
+    } else if ((strstr(path, "://") && !strchr(path, ' ')) || !strncmp(path, "about:", 6)) {
+        /* If path contains :// but no space we open it direct. This is required
+         * to use :// also with shortcuts */
         uri = g_strdup(path);
     } else if (stat(path, &st) == 0) {
         /* check if the path is a file path */


### PR DESCRIPTION
It helps me if browsers can read page content from stdin (like lynx, elinks).
Suppose previewing markdown page like:

```
$ markdown_py README.md | ./vimb -
```

Argument '-' stands for stdin, of cource.
