### PR TITLE
Cookie expire time

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1108,6 +1108,13 @@ cookies)}.
 .B cookie-timeout (int)
 Cookie timeout in seconds.
 .TP
+.B cookie-expire-time (int)
+Enforce expire-time on cookies. The default value `-1' keep expire-time as
+defined by server side. The value `0' convert all cookies as session-only
+cookies (`cookie-timeout' setting is used as for any other session-cookie). Any
+other value enforce the expire-time (the expire-time value will be the lower
+between server-side request and time defined with `cookie-expire-time').
+.TP
 .B download-command (string)
 A command with placeholder '%s' that will be invoked to download a uri.
 .RS

--- a/src/cookiejar.c
+++ b/src/cookiejar.c
@@ -49,10 +49,25 @@ static void cookiejar_changed(SoupCookieJar *self, SoupCookie *old_cookie, SoupC
 {
     FLOCK(COOKIEJAR(self)->lock, F_WRLCK);
     SoupDate *expire;
-    if (new_cookie && !new_cookie->expires && vb.config.cookie_timeout) {
-        expire = soup_date_new_from_now(vb.config.cookie_timeout);
-        soup_cookie_set_expires(new_cookie, expire);
-        soup_date_free(expire);
+    if (new_cookie) {
+	/* session-expire-time handling */
+	if (vb.config.cookie_expire_time == 0) {
+	    soup_cookie_set_expires(new_cookie, NULL);
+
+	} else if (vb.config.cookie_expire_time > 0 && new_cookie->expires) {
+	    expire = soup_date_new_from_now(vb.config.cookie_expire_time);
+	    if (soup_date_to_time_t(expire) < soup_date_to_time_t(new_cookie->expires)) {
+		soup_cookie_set_expires(new_cookie, expire);
+	    }
+	    soup_date_free(expire);
+	}
+
+	/* session-cookie handling */
+	if (!new_cookie->expires && vb.config.cookie_timeout) {
+	    expire = soup_date_new_from_now(vb.config.cookie_timeout);
+	    soup_cookie_set_expires(new_cookie, expire);
+	    soup_date_free(expire);
+	}
     }
     SOUP_COOKIE_JAR_CLASS(cookiejar_parent_class)->changed(self, old_cookie, new_cookie);
     FLOCK(COOKIEJAR(self)->lock, F_UNLCK);

--- a/src/main.h
+++ b/src/main.h
@@ -309,6 +309,7 @@ typedef struct {
 typedef struct {
 #ifdef FEATURE_COOKIE
     time_t       cookie_timeout;
+    int		 cookie_expire_time;
 #endif
     int          scrollstep;
     char         *download_dir;

--- a/src/setting.c
+++ b/src/setting.c
@@ -163,6 +163,8 @@ void setting_init()
     setting_add("cookie-accept", TYPE_CHAR, &"always", cookie_accept, 0, NULL);
     i = 4800;
     setting_add("cookie-timeout", TYPE_INTEGER, &i, internal, 0, &vb.config.cookie_timeout);
+    i = -1;
+    setting_add("cookie-expire-time", TYPE_INTEGER, &i, internal, 0, &vb.config.cookie_expire_time);
 #endif
     setting_add("strict-ssl", TYPE_BOOLEAN, &on, soup, 0, "ssl-strict");
     setting_add("strict-focus", TYPE_BOOLEAN, &off, internal, 0, &vb.config.strict_focus);


### PR DESCRIPTION
As discuted in #118 about enforcing cookie expire time, here an implementation.
- add cookie-expire-time configuration setting
- document the new setting
- with cookie-expire-time=0 : cookies are converted to session-cookies (expires=NULL)
- with cookie-expire-time>0 : cookies' expire-time is the lower between server-side request and cookie-expire-time
- with cookie-expire-time<0 : the expire time is left as server-side define it. It is the default.
