### PR TITLE
Content security policy

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -630,7 +630,8 @@ Events:
 .TP
 .B LoadProvisional
 Fired if a new page is going to opened. No data has been received yet, the load
-may still fail for transport issues.
+may still fail for transport issues. This is the right event to set `content-security-policy'
+setting.
 .TP
 .B LoadCommited
 Fired if first data chunk has arrived, meaning that the necessary transport
@@ -1189,6 +1190,25 @@ Example:
 .IP ":set header=DNT=1,User-Agent,Cookie='name=value'"
 Send the 'Do Not Track' header with each request and remove the User-Agent
 Header completely from request.
+.PD
+.RE
+.TP
+.B content-security-policy (string)
+Prepend a `Content-Security-Policy' HTTP-Header to responses received from server.
+This setting has to be setted early if managed with `autocmd' (at LoadProvisional),
+in order to be managed by webkit.
+
+It could be used to implement a whitelist policy for visited uri.
+
+Note that this setting will not remplace existing headers, but add one.
+
+Please refer to `http://www.w3.org/TR/CSP/' for syntax.
+.RS
+.PP
+Example:
+.PD 0
+.IP ":set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'none'"
+Webkit will see the `Content-Security-Policy' header defined with each response.
 .PD
 .RE
 .TP

--- a/src/main.h
+++ b/src/main.h
@@ -317,6 +317,7 @@ typedef struct {
     guint        timeoutlen;      /* timeout for ambiguous mappings */
     gboolean     strict_focus;
     GHashTable   *headers;        /* holds user defined header appended to requests */
+    char         *contentsecuritypolicy; /* holds user defined Content-Security-Policy */
     char         *nextpattern;    /* regex patter nfor prev link matching */
     char         *prevpattern;    /* regex patter nfor next link matching */
     char         *file;           /* path to the custome config file */

--- a/src/setting.c
+++ b/src/setting.c
@@ -203,6 +203,7 @@ void setting_init()
     setting_add("history-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.history_max);
     setting_add("editor-command", TYPE_CHAR, &"x-terminal-emulator -e -vi '%s'", NULL, 0, NULL);
     setting_add("header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, NULL);
+    setting_add("content-security-policy", TYPE_CHAR, &"", internal, 0, &vb.config.contentsecuritypolicy);
     setting_add("nextpattern", TYPE_CHAR, &"/\\bnext\\b/i,/^(>\\|>>\\|»)$/,/^(>\\|>>\\|»)/,/(>\\|>>\\|»)$/,/\\bmore\\b/i", prevnext, FLAG_LIST|FLAG_NODUP, NULL);
     setting_add("previouspattern", TYPE_CHAR, &"/\\bprev\\|previous\\b/i,/^(<\\|<<\\|«)$/,/^(<\\|<<\\|«)/,/(<\\|<<\\|«)$/", prevnext, FLAG_LIST|FLAG_NODUP, NULL);
     setting_add("fullscreen", TYPE_BOOLEAN, &off, fullscreen, 0, NULL);


### PR DESCRIPTION
Hi Carl,

I have implemented a setting to enforce Content-Security-Policy (see http://www.w3.org/TR/CSP/). Basically, it add a HTTP-Header on libsoup response, and when webkit process it, it manage the HTTP-Header as it would be send by the server.

The purpose is to have a system the user could setup to whitelist requests (I am on "https://github.com" so you could load any page in "github.com" domain or "githubusercontent.com" domain, but nowhere else).

In order to have a setting customisable by autocmd, I have change LoadProvisional for permit matching the uri (I take the uri of the provisonal data source). Webkit use the HTTP-Header setting before LoadCommited, so setting it here have no effect.

I have just a problem with autocmd: if the page perform a redirection, LoadProvisional isn't called a second time. So the wrong policy could be applied. For example: `https://www.oxdef.info/csp-reporter` will redirect to `https://github.com/yandex/csp-reporter`, but it is the policy for oxdef that will be applied.

The policy-errors are printed by webkit on terminal console the error message:

```
** Message: console message:  @0: Refused to load the image 'https://camo.githubusercontent.com/stripped' because it violates the following Content Security Policy directive: "default-src 'self' 'unsafe-inline' 'unsafe-eval' data:". Note that 'img-src' was not explicitly set, so 'default-src' is used as a fallback.
```

As example, here a piece of the config I currently use:

```
augroup csp
  # default for all sites: same domain only
  autocmd LoadProvisional * set content-security-policy=default-src 'self' 

  # default for https sites: same domain + inline + data: scheme
  autocmd LoadProvisional https://* set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' data:

  # github configuration
  #  + any domain of github.com and githubusercontent.com
  autocmd LoadProvisional https://github.com/* set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://*.github.com/ https://*.githubusercontent.com/

  autocmd LoadProvisional https://*.github.com/* set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://*.github.com/ https://*.githubusercontent.com/

  # twitter configuration
  # + any domain from twitter.com and twimg.com
  autocmd LoadProvisional https://twitter.com/* set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://*.twitter.com/ https://*.twimg.com/

  # mozilla.org configuration
  # + any domain from mozilla.net
  autocmd LoadProvisional https://*.mozilla.org/* set content-security-policy=default-src 'self' 'unsafe-inline' 'unsafe-eval' data: https://*.mozilla.net/
augroup end
```
