### PR TITLE
keep prototype consistant with declaration

### DIFF
--- a/src/hsts.c
+++ b/src/hsts.c
@@ -45,7 +45,7 @@ typedef struct {
 static void hsts_provider_class_init(HSTSProviderClass *klass);
 static void hsts_provider_init(HSTSProvider *self);
 static void hsts_provider_finalize(GObject* obj);
-static gboolean should_secure_host(HSTSProvider *provider,
+static inline gboolean should_secure_host(HSTSProvider *provider,
     const char *host);
 static void process_hsts_header(SoupMessage *msg, gpointer data);
 static void parse_hsts_header(HSTSProvider *provider,


### PR DESCRIPTION
Hi Daniel,

Just a cleanup... (I generally compile with -Werror setted)

The commit remove a compilation warning:
src/hsts.c:49: warning: 'should_secure_host' declared inline after being called
src/hsts.c:49: warning: previous declaration of 'should_secure_host' was here

the declaration and the prototype of  `should_secure_host` aren't same (`inline` not present in protype)
