### PR TITLE
allow/disallow page-request opening of new window

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1293,6 +1293,13 @@ If 'on', vimb will not load a untrusted https site.
 .B stylesheet (bool)
 If 'on' the user defined styles-sheet is used.
 .TP
+.B allow-page-request-open-window (bool)
+If 'on' (the default), vimb will allow opening new window per page request.
+This change the behaviour for javascript function `window.open` or
+`target="_blank"` attribute link. If 'off', the page will be opened in the same
+window. The setting don't alter user request of new window (with `:tabopen`,
+hints...)
+.TP
 .B timeoutlen (int)
 The time in milliseconds that is waited for a key code or mapped key sequence
 to complete.

--- a/src/ex.c
+++ b/src/ex.c
@@ -826,7 +826,7 @@ static gboolean ex_normal(const ExArg *arg)
 static gboolean ex_open(const ExArg *arg)
 {
     if (arg->code == EX_TABOPEN) {
-        return vb_load_uri(&((Arg){VB_TARGET_NEW, arg->rhs->str}));
+        return vb_load_uri(&((Arg){VB_TARGET_NEW_USER_REQUEST, arg->rhs->str}));
     }
     return vb_load_uri(&((Arg){VB_TARGET_CURRENT, arg->rhs->str}));
 }

--- a/src/hints.c
+++ b/src/hints.c
@@ -327,7 +327,7 @@ static gboolean call_hints_function(const char *func, int count, JSValueRef para
             case 'i':
             case 'I':
                 a.s = v;
-                a.i = (hints.mode == 'I') ? VB_TARGET_NEW : VB_TARGET_CURRENT;
+                a.i = (hints.mode == 'I') ? VB_TARGET_NEW_USER_REQUEST : VB_TARGET_CURRENT;
                 vb_load_uri(&a);
                 break;
 

--- a/src/main.c
+++ b/src/main.c
@@ -209,7 +209,8 @@ gboolean vb_load_uri(const Arg *arg)
         uri = g_strconcat("http://", path, NULL);
     }
 
-    if (arg->i == VB_TARGET_NEW) {
+    if (((arg->i == VB_TARGET_NEW_PAGE_REQUEST) && vb.config.page_request_open_window)
+            || (arg->i == VB_TARGET_NEW_USER_REQUEST)) {
         guint i = 0;
 
         /* memory allocation */
@@ -1153,7 +1154,7 @@ static gboolean button_relase_cb(WebKitWebView *webview, GdkEventButton *event)
     if (context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK
         && (event->button == 2 || (event->button == 1 && event->state & GDK_CONTROL_MASK))
     ) {
-        Arg a = {VB_TARGET_NEW};
+        Arg a = {VB_TARGET_NEW_USER_REQUEST};
         g_object_get(result, "link-uri", &a.s, NULL);
         vb_load_uri(&a);
 
@@ -1187,7 +1188,7 @@ static gboolean new_window_policy_cb(
     if (webkit_web_navigation_action_get_reason(navig) == WEBKIT_WEB_NAVIGATION_REASON_LINK_CLICKED) {
         webkit_web_policy_decision_ignore(policy);
         /* open in a new window */
-        Arg a = {VB_TARGET_NEW, (char*)webkit_network_request_get_uri(request)};
+        Arg a = {VB_TARGET_NEW_PAGE_REQUEST, (char*)webkit_network_request_get_uri(request)};
         vb_load_uri(&a);
         return true;
     }
@@ -1209,7 +1210,7 @@ static gboolean create_web_view_received_uri_cb(WebKitWebView *view,
     WebKitWebNavigationAction *action, WebKitWebPolicyDecision *policy,
     gpointer data)
 {
-    Arg a = {VB_TARGET_NEW, (char*)webkit_network_request_get_uri(request)};
+    Arg a = {VB_TARGET_NEW_PAGE_REQUEST, (char*)webkit_network_request_get_uri(request)};
     vb_load_uri(&a);
 
     /* destroy temporary webview */

--- a/src/main.h
+++ b/src/main.h
@@ -147,7 +147,8 @@ enum {
 
 enum {
     VB_TARGET_CURRENT,
-    VB_TARGET_NEW
+    VB_TARGET_NEW_PAGE_REQUEST,
+    VB_TARGET_NEW_USER_REQUEST
 };
 
 enum {
@@ -314,6 +315,7 @@ typedef struct {
     int          scrollstep;
     char         *download_dir;
     guint        history_max;
+    gboolean     page_request_open_window; /* allow open new window on page request */
     guint        timeoutlen;      /* timeout for ambiguous mappings */
     gboolean     strict_focus;
     GHashTable   *headers;        /* holds user defined header appended to requests */

--- a/src/normal.c
+++ b/src/normal.c
@@ -416,7 +416,7 @@ static VbResult normal_g_cmd(const NormalCmdInfo *info)
 
         case 'H':
         case 'h':
-            a.i = info->key2 == 'H' ? VB_TARGET_NEW : VB_TARGET_CURRENT;
+            a.i = info->key2 == 'H' ? VB_TARGET_NEW_USER_REQUEST : VB_TARGET_CURRENT;
             a.s = NULL;
             vb_load_uri(&a);
             return RESULT_COMPLETE;
@@ -541,7 +541,7 @@ static VbResult normal_navigate(const NormalCmdInfo *info)
 
 static VbResult normal_open_clipboard(const NormalCmdInfo *info)
 {
-    Arg a = {info->key == 'P' ? VB_TARGET_NEW : VB_TARGET_CURRENT};
+    Arg a = {info->key == 'P' ? VB_TARGET_NEW_USER_REQUEST : VB_TARGET_CURRENT};
 
     /* if cutbuffer is not the default - read out of the internal cutbuffer */
     if (info->cutbuf) {
@@ -568,7 +568,7 @@ static VbResult normal_open(const NormalCmdInfo *info)
 {
     Arg a;
     /* open last closed */
-    a.i = info->key == 'U' ? VB_TARGET_NEW : VB_TARGET_CURRENT;
+    a.i = info->key == 'U' ? VB_TARGET_NEW_USER_REQUEST : VB_TARGET_CURRENT;
     a.s = util_get_file_contents(vb.files[FILES_CLOSED], NULL);
     vb_load_uri(&a);
     g_free(a.s);

--- a/src/setting.c
+++ b/src/setting.c
@@ -180,6 +180,7 @@ void setting_init()
     setting_add("status-sslinvalid-color-bg", TYPE_COLOR, &"#ff7777", status_color, 0, &vb.style.status_bg[VB_STATUS_SSL_INVALID]);
     setting_add("status-sslinvalid-color-fg", TYPE_COLOR, &"#000000", status_color, 0, &vb.style.status_fg[VB_STATUS_SSL_INVALID]);
     setting_add("status-sslinvalid-font", TYPE_FONT, &SETTING_GUI_FONT_EMPH, status_font, 0, &vb.style.status_font[VB_STATUS_SSL_INVALID]);
+    setting_add("allow-page-request-open-window", TYPE_BOOLEAN, &on, internal, 0, &vb.config.page_request_open_window);
     i = 1000;
     setting_add("timeoutlen", TYPE_INTEGER, &i, internal, 0, &vb.config.timeoutlen);
     setting_add("input-autohide", TYPE_BOOLEAN, &off, input_autohide, 0, &vb.config.input_autohide);


### PR DESCRIPTION
Hi Daniel,

I add a new setting to control opening new window made by page request
(window.open javascript or target="_blank"). The user request opening of
new window isn't changed (tabopen, hints, ...).

The implementation split `VB_TARGET_NEW` (used in `vb_load_uri`) in `VB_TARGET_NEW_PAGE_REQUEST` and `VB_TARGET_NEW_USER_REQUEST`.

Any user action that performed `VB_TARGET_NEW` is converted to
`VB_TARGET_NEW_USER_REQUEST`, and others to `VB_TARGET_NEW_PAGE_REQUEST`.

The behaviour of `VB_TARGET_NEW_USER_REQUEST` is the same as `VB_TARGET_NEW`.
The behaviour of `VB_TARGET_NEW_PAGE_REQUEST` is controlled by the setting. If  `allow-page-request-open-window` is `on` (the default), the behaviour is same as `VB_TARGET_NEW`, else behaviour is like `VB_TARGET_CURRENT`.

Use case: I use always `cookie-timeout=0`, in order to keep session cookies in memory, and don't share session cookies across vimb instances. But as result, when a site open a new window, the session cookie isn't here. The setting could mitigate the problem by disallowing a site to open a new window, but to force it to use the current instance.
