### PR TITLE
Add backspace to special keys for mapping

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -516,7 +516,7 @@ number of keys have no visual representation, a special notation is required.
 .PP
 As special key names have the format \fI<...>\fP.
 The following special keys can be used: <Left>, <Up>, <Right>, <Down>
-for the cursor keys, <Tab>, <Esc>, <CR>, <Space>, <F1>-<F12> and <C-A>-<C-Z>.
+for the cursor keys, <Tab>, <Esc>, <CR>, <Space>, <BS>, <F1>-<F12> and <C-A>-<C-Z>.
 .TP
 .BI ":nm[ap] {" lhs "} {" rhs }
 .TP

--- a/src/map.c
+++ b/src/map.c
@@ -93,6 +93,7 @@ static struct {
     {"<S-Tab>", 7, CSI_STR "kB", 3},
     {"<Esc>",   5, "\x1b",       1},
     {"<Space>", 7, "\x20",       1},
+    {"<BS>",    4, "\x08",       1},
     {"<Up>",    4, CSI_STR "ku", 3},
     {"<Down>",  6, CSI_STR "kd", 3},
     {"<Left>",  6, CSI_STR "kl", 3},


### PR DESCRIPTION
Add backspace to mapping characters under the name <BS> to match vim's behaviour