### PR TITLE
Added hint-follow-last option

### DIFF
--- a/src/hints.c
+++ b/src/hints.c
@@ -162,8 +162,9 @@ void hints_create(const char *input)
             JSValueMakeBoolean(hints.ctx, hints.gmode),
             JSValueMakeNumber(hints.ctx, MAXIMUM_HINTS),
             js_string_to_ref(hints.ctx, GET_CHAR("hintkeys")),
+            JSValueMakeBoolean(hints.ctx, GET_BOOL("hint-follow-last"))
         };
-        call_hints_function("init", 4, arguments);
+        call_hints_function("init", 5, arguments);
 
         /* if hinting is started there won't be any additional filter given and
          * we can go out of this function */

--- a/src/hints.js
+++ b/src/hints.js
@@ -278,7 +278,7 @@ Object.freeze((function(){
                 }
             }
         }
-        if (fireLast && validHints.length <= 1) {
+        if (config.followLast && fireLast && validHints.length <= 1) {
             focusHint(0);
             return fire();
         }
@@ -544,7 +544,7 @@ Object.freeze((function(){
 
     /* the api */
     return {
-        init: function init(mode, keepOpen, maxHints, hintKeys) {
+        init: function init(mode, keepOpen, maxHints, hintKeys, followLast) {
             var prop,
                 /* holds the xpaths for the different modes */
                 xpathmap = {
@@ -561,6 +561,7 @@ Object.freeze((function(){
                     Y:          function(e) {return "DATA:" + (e.textContent || "");}
                 };
 
+            console.log("Follow last: ", followLast);
             config = {
                 maxHints:   maxHints,
                 keepOpen:   keepOpen,
@@ -568,7 +569,8 @@ Object.freeze((function(){
                 /* don't handle form for Y to allow to yank form filed content */
                 /* instead of switching to input mode */
                 handleForm: ("eot".indexOf(mode) >= 0),
-                hintKeys:   hintKeys
+                hintKeys:   hintKeys,
+                followLast: followLast,
             };
             for (prop in xpathmap) {
                 if (prop.indexOf(mode) >= 0) {
@@ -603,7 +605,7 @@ Object.freeze((function(){
             }
             if ((pos = keys.indexOf(n)) >= 0) {
                 filterNum = filterNum * keys.length + pos;
-                return show(true);
+            return show(true);
             }
             return "ERROR:";
         },

--- a/src/hints.js
+++ b/src/hints.js
@@ -561,7 +561,6 @@ Object.freeze((function(){
                     Y:          function(e) {return "DATA:" + (e.textContent || "");}
                 };
 
-            console.log("Follow last: ", followLast);
             config = {
                 maxHints:   maxHints,
                 keepOpen:   keepOpen,
@@ -605,7 +604,7 @@ Object.freeze((function(){
             }
             if ((pos = keys.indexOf(n)) >= 0) {
                 filterNum = filterNum * keys.length + pos;
-            return show(true);
+                return show(true);
             }
             return "ERROR:";
         },

--- a/src/hints.js
+++ b/src/hints.js
@@ -278,7 +278,7 @@ Object.freeze((function(){
                 }
             }
         }
-        if (config.followLast && fireLast && validHints.length <= 1) {
+        if (fireLast && config.followLast && validHints.length <= 1) {
             focusHint(0);
             return fire();
         }

--- a/src/main.h
+++ b/src/main.h
@@ -325,29 +325,29 @@ typedef struct {
     int          scrollstep;
     char         *download_dir;
     guint        history_max;
-    guint        timeoutlen;      /* timeout for ambiguous mappings */
+    guint        timeoutlen;       /* timeout for ambiguous mappings */
     gboolean     strict_focus;
-    GHashTable   *headers;        /* holds user defined header appended to requests */
+    GHashTable   *headers;         /* holds user defined header appended to requests */
 #ifdef FEATURE_ARH
     GSList       *autoresponseheader; /* holds user defined list of auto-response-header */
 #endif
-    char         *nextpattern;    /* regex patter nfor prev link matching */
-    char         *prevpattern;    /* regex patter nfor next link matching */
-    char         *file;           /* path to the custome config file */
-    GSList       *cmdargs;        /* list of commands given by --cmd option */
-    char         *cafile;         /* path to the ca file */
-    GTlsDatabase *tls_db;         /* tls database */
-    float        default_zoom;    /* default zoomlevel that is applied on zz zoom reset */
+    char         *nextpattern;     /* regex patter nfor prev link matching */
+    char         *prevpattern;     /* regex patter nfor next link matching */
+    char         *file;            /* path to the custome config file */
+    GSList       *cmdargs;         /* list of commands given by --cmd option */
+    char         *cafile;          /* path to the ca file */
+    GTlsDatabase *tls_db;          /* tls database */
+    float        default_zoom;     /* default zoomlevel that is applied on zz zoom reset */
     gboolean     kioskmode;
-    gboolean     input_autohide;  /* indicates if the inputbox should be hidden if it's empty */
+    gboolean     input_autohide;   /* indicates if the inputbox should be hidden if it's empty */
 #ifdef FEATURE_SOCKET
-    gboolean     socket;          /* indicates if the socket is used */
+    gboolean     socket;           /* indicates if the socket is used */
 #endif
 #ifdef FEATURE_HSTS
-    HSTSProvider *hsts_provider;  /* the hsts session feature that is added to soup session */
+    HSTSProvider *hsts_provider;   /* the hsts session feature that is added to soup session */
 #endif
 #ifdef FEATURE_SOUP_CACHE
-    SoupCache    *soup_cache;     /* soup caching feature model */
+    SoupCache    *soup_cache;      /* soup caching feature model */
 #endif
     GHashTable   *settings;
 } Config;

--- a/src/setting.c
+++ b/src/setting.c
@@ -203,6 +203,7 @@ void setting_init()
     i = 1000;
     setting_add("hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
     setting_add("hintkeys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
+    setting_add("hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);
     setting_add("download-path", TYPE_CHAR, &"", internal, 0, &vb.config.download_dir);
     i = 2000;
     setting_add("history-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.history_max);


### PR DESCRIPTION
Trying to resolve issue #184, I added a new option called `hint-follow-last` that will toggle the behaviour of vimb to automatically follow the last remaining hint.  This behaviour is by default turned to `hint-follow-last=True` to continue with expected behaviour.