### PR TITLE
Minor corrections in formfiller exemple

### DIFF
--- a/examples/formfiller/formfiller
+++ b/examples/formfiller/formfiller
@@ -14,7 +14,7 @@
 # dmenu command use in case multiple files are found for current domain
 DMENU="dmenu -l 7"
 
-if [[ -z $XDG_CONFIG_HOME ]]
+if [[ -z "$XDG_CONFIG_HOME" ]]
 then
         XDG_CONFIG_HOME=$HOME/.config
 fi

--- a/examples/formfiller/formfiller
+++ b/examples/formfiller/formfiller
@@ -12,7 +12,12 @@
 # ["input[name='user']:daniel", "input[name='password']:p45w0rD"]
 
 # dmenu command use in case multiple files are found for current domain
-DMENU="dmenu -l7"
+DMENU="dmenu -l 7"
+
+if [[ -z $XDG_CONFIG_HOME ]]
+then
+        XDG_CONFIG_HOME=$HOME/.config
+fi
 
 VIMB_KEY_DIR=${VIMB_KEY_DIR:-"$XDG_CONFIG_HOME/vimb/keys"}
 uri=$1


### PR DESCRIPTION
My dmenu does not know any ```-l7``` option, neither does the manual, I just added a space to make things work.

What's more I don't have any ```$XDG_*``` set by default, so I added an emptyness check and if the variable does not exist then the default value as recommanded [here](https://developer.gnome.org/basedir-spec/) is set.

Thanks for your work !