### PR TITLE
enable input-mode on input.search element

### DIFF
--- a/src/dom.c
+++ b/src/dom.c
@@ -140,7 +140,8 @@ gboolean dom_is_editable(Element *element)
     if (!g_ascii_strcasecmp(tagname, "textarea")) {
         result = true;
     } else if (!g_ascii_strcasecmp(tagname, "input")
-        && (!*type || !g_ascii_strcasecmp(type, "text") || !g_ascii_strcasecmp(type, "password"))
+        && (!*type || !g_ascii_strcasecmp(type, "text") || !g_ascii_strcasecmp(type, "password")
+		|| !g_ascii_strcasecmp(type, "search"))
     ) {
         result = true;
     } else {


### PR DESCRIPTION
HTML5 define a new input type="search":
http://www.w3.org/TR/html-markup/input.search.html

declare this element to be editable, in order to switch in input-mode
when use it.

A possible webpage for test is http://doc.rust-lang.org/std/