### PR TITLE
Added hint-number-same-length option

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1370,6 +1370,10 @@ Header completely from request.
 If on, vimb automatically follows the last remaining hint on the page.
 If off hints are fired only if enter is pressed.
 .TP
+.B hint-number-same-length (bool)
+If on, all hint numbers will have the same length, so no hints will be
+ambiguous.
+.TP
 .B hint-timeout (int)
 Timeout before automatically following a non-unique numerical hint.
 To disable auto fire of hints, set this value to 0.

--- a/src/hints.c
+++ b/src/hints.c
@@ -162,9 +162,10 @@ void hints_create(const char *input)
             JSValueMakeBoolean(hints.ctx, hints.gmode),
             JSValueMakeNumber(hints.ctx, MAXIMUM_HINTS),
             js_string_to_ref(hints.ctx, GET_CHAR("hintkeys")),
-            JSValueMakeBoolean(hints.ctx, GET_BOOL("hint-follow-last"))
+            JSValueMakeBoolean(hints.ctx, GET_BOOL("hint-follow-last")),
+            JSValueMakeBoolean(hints.ctx, GET_BOOL("hint-number-same-length"))
         };
-        call_hints_function("init", 5, arguments);
+        call_hints_function("init", 6, arguments);
 
         /* if hinting is started there won't be any additional filter given and
          * we can go out of this function */

--- a/src/hints.js
+++ b/src/hints.js
@@ -234,6 +234,22 @@ Object.freeze((function(){
             matcher = getMatcher(filterText),
             str     = getHintString(filterNum);
 
+        if (config.hintNumSameLength) {
+            /* get number of hints to be shown */
+            var hintCount = 0;
+            for (i = 0; i < hints.length; i++) {
+                if (matcher(hints[i].text)) {
+                    hintCount++;
+                }
+            }
+            /* increase starting point of hint numbers until there are */
+            /* enough available numbers */
+            var len = config.hintKeys.length;
+            while (n * (len - 1) < hintCount) {
+                n *= len;
+            }
+        }
+
         /* clear the array of valid hints */
         validHints = [];
         for (i = 0; i < hints.length; i++) {
@@ -520,7 +536,7 @@ Object.freeze((function(){
 
     /* the api */
     return {
-        init: function init(mode, keepOpen, maxHints, hintKeys, followLast) {
+        init: function init(mode, keepOpen, maxHints, hintKeys, followLast, hintNumSameLength) {
             var prop,
                 /* holds the xpaths for the different modes */
                 xpathmap = {
@@ -543,9 +559,10 @@ Object.freeze((function(){
                 /* handle forms only useful when there are form fields in xpath */
                 /* don't handle form for Y to allow to yank form filed content */
                 /* instead of switching to input mode */
-                handleForm: ("eot".indexOf(mode) >= 0),
-                hintKeys:   hintKeys,
-                followLast: followLast,
+                handleForm:        ("eot".indexOf(mode) >= 0),
+                hintKeys:          hintKeys,
+                followLast:        followLast,
+                hintNumSameLength: hintNumSameLength,
             };
             for (prop in xpathmap) {
                 if (prop.indexOf(mode) >= 0) {

--- a/src/setting.c
+++ b/src/setting.c
@@ -204,6 +204,7 @@ void setting_init()
     setting_add("hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
     setting_add("hintkeys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
     setting_add("hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);
+    setting_add("hint-number-same-length", TYPE_BOOLEAN, &off, NULL, 0, NULL);
     setting_add("download-path", TYPE_CHAR, &"", internal, 0, &vb.config.download_dir);
     i = 2000;
     setting_add("history-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.history_max);


### PR DESCRIPTION
This option makes all hint numbers have the same length. With this option on there is no need to wait for `hint-timeout` or hit enter after entering the hint number, because it will not be ambiguous.
