### PR TITLE
Made build process more user-friendly

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -9,6 +9,8 @@ EXAMPLEDIR ?= $(PREFIX)/share/$(PROJECT)/examples
 
 #----------------compile options---------------------
 
+VERBOSE ?= 0
+
 LIBS = libsoup-2.4
 
 GTK3LIBS=gtk+-3.0 webkitgtk-3.0
@@ -44,12 +46,12 @@ endif
 # prepare the lib flags used for the linker
 LIBFLAGS = $(shell pkg-config --libs $(LIBS))
 
+# some compiler flags in case CFLAGS is not set by user
+# -Wno-typedef-redefinition to avoid redifinition warnings caused by glib
+CFLAGS  ?= -Wall -pipe -Wno-overlength-strings -Werror=format-security -Wno-typedef-redefinition
 # normal compiler flags
 CFLAGS  += $(shell pkg-config --cflags $(LIBS))
-CFLAGS  += -Wall -pipe -std=c99
-CFLAGS  += -Wno-overlength-strings -Werror=format-security
-# This is to avoid redifinition warnings caused by glib.
-CFLAGS  += -Wno-typedef-redefinition
+CFLAGS  += -std=c99
 CFLAGS  += ${CPPFLAGS}
 LDFLAGS += ${LIBFLAGS}
 
@@ -58,4 +60,4 @@ LIBTARGET = lib$(PROJECT).so
 DIST_FILE = $(PROJECT)_$(VERSION).tar.gz
 MAN1      = $(PROJECT).1
 
-MFLAGS    = --no-print-directory
+MFLAGS   ?= --no-print-directory

--- a/src/Makefile
+++ b/src/Makefile
@@ -23,24 +23,40 @@ $(OBJ):  config.h $(BASEDIR)/config.mk
 $(LOBJ): config.h $(BASEDIR)/config.mk
 
 $(TARGET): $(OBJ)
+ifeq ($(VERBOSE),0)
+	$(CC) $(OBJ) -o $@ $(LDFLAGS)
+else
 	@echo "$(CC) $@"
 	@$(CC) $(OBJ) -o $@ $(LDFLAGS)
+endif
 
 $(LIBTARGET): $(LOBJ)
+ifeq ($(VERBOSE),0)
+	$(CC) -shared ${LOBJ} -o $@ $(LDFLAGS)
+else
 	@echo "$(CC) $@"
 	@$(CC) -shared ${LOBJ} -o $@ $(LDFLAGS)
+endif
 
 config.h:
 	@echo create $@ from config.def.h
 	@cp config.def.h $@
 
 %.o: %.c %.h
+ifeq ($(VERBOSE),0)
 	@echo "${CC} $@"
 	@$(CC) $(CFLAGS) -c -o $@ $<
+else
+	$(CC) $(CFLAGS) -c -o $@ $<
+endif
 
 %.lo: %.c %.h
+ifeq ($(VERBOSE),0)
 	@echo "${CC} $@"
 	@$(CC) -DTESTLIB $(CFLAGS) -fPIC -c -o $@ $<
+else
+	$(CC) -DTESTLIB $(CFLAGS) -fPIC -c -o $@ $<
+endif
 
 -include $(OBJ:.o=.d)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,10 +32,10 @@ endif
 
 $(LIBTARGET): $(LOBJ)
 ifeq ($(VERBOSE),0)
-	$(CC) -shared ${LOBJ} -o $@ $(LDFLAGS)
-else
 	@echo "$(CC) $@"
 	@$(CC) -shared ${LOBJ} -o $@ $(LDFLAGS)
+else
+	$(CC) -shared ${LOBJ} -o $@ $(LDFLAGS)
 endif
 
 config.h:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ SRCDIR=$(BASEDIR)/src
 include $(BASEDIR)/config.mk
 
 CPPFLAGS += -I $(BASEDIR)/
-CFLAGS   += -fPIC -Wpedantic
+CFLAGS   += -fPIC -pedantic
 
 TEST_PROGS = test-handlers \
 			 test-map      \


### PR DESCRIPTION
Set CFLAGS that are not absolutely required with CFLAGS?=..., so that
user-defined CFLAGS take precedence.  Made VERBOSE option that would toggle
between silent (previous) and verbose mode of CC directive processing.