### PR TITLE
Fix the title after going back to a local file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -746,6 +746,7 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
 
             vb_update_statusbar();
             set_uri(uri);
+            set_title(uri);
             /* save the current URI in register % */
             vb_register_add('%', uri);
 


### PR DESCRIPTION
If you open a local file, open a web page, and go back, the title
of the web page will still be shown. This is a fix.
