### PR TITLE
The input mode should be entered at the right time when a web page is being loaded.

### DIFF
--- a/src/dom.h
+++ b/src/dom.h
@@ -32,6 +32,8 @@
 #define HtmlInputElement    WebKitDOMHTMLInputElement
 #define HtmlTextareaElement WebKitDOMHTMLTextAreaElement
 
+void dom_install_focus_blur_callbacks(Document *doc);
+void dom_auto_insert_unless_strict_focus(Document *doc);
 void dom_check_auto_insert(Document *doc);
 void dom_clear_focus(WebKitWebView *view);
 gboolean dom_focus_input(Document *doc);

--- a/src/main.c
+++ b/src/main.c
@@ -763,10 +763,6 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
             if (vb.mode->id == 'i') {
                 vb_enter('n');
             }
-
-            WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
-            dom_check_auto_insert(webkit_web_frame_get_dom_document(frame));
-
             break;
 
         case WEBKIT_LOAD_FINISHED:
@@ -1149,6 +1145,7 @@ static void setup_signals()
         "signal::should-show-delete-interface-for-element", G_CALLBACK(gtk_false), NULL,
         "signal::resource-request-starting", G_CALLBACK(webview_request_starting_cb), NULL,
         "signal::navigation-policy-decision-requested", G_CALLBACK(navigation_decision_requested_cb), NULL,
+        "signal::onload-event", G_CALLBACK(onload_event_cb), NULL,
         NULL
     );
 
@@ -1424,6 +1421,13 @@ static gboolean navigation_decision_requested_cb(WebKitWebView *view,
         return true;
     }
     return false;
+}
+
+static void onload_event_cb(WebKitWebView *view, WebKitWebFrame *frame,
+    gpointer user_data)
+{
+    Document *doc = webkit_web_frame_get_dom_document(frame);
+    dom_check_auto_insert(doc);
 }
 
 static void hover_link_cb(WebKitWebView *webview, const char *title, const char *link)

--- a/src/main.c
+++ b/src/main.c
@@ -763,6 +763,10 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
             if (vb.mode->id == 'i') {
                 vb_enter('n');
             }
+
+            WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
+            dom_check_auto_insert(webkit_web_frame_get_dom_document(frame));
+
             break;
 
         case WEBKIT_LOAD_FINISHED:
@@ -1145,7 +1149,6 @@ static void setup_signals()
         "signal::should-show-delete-interface-for-element", G_CALLBACK(gtk_false), NULL,
         "signal::resource-request-starting", G_CALLBACK(webview_request_starting_cb), NULL,
         "signal::navigation-policy-decision-requested", G_CALLBACK(navigation_decision_requested_cb), NULL,
-        "signal::onload-event", G_CALLBACK(onload_event_cb), NULL,
         NULL
     );
 
@@ -1421,13 +1424,6 @@ static gboolean navigation_decision_requested_cb(WebKitWebView *view,
         return true;
     }
     return false;
-}
-
-static void onload_event_cb(WebKitWebView *view, WebKitWebFrame *frame,
-    gpointer user_data)
-{
-    Document *doc = webkit_web_frame_get_dom_document(frame);
-    dom_check_auto_insert(doc);
 }
 
 static void hover_link_cb(WebKitWebView *webview, const char *title, const char *link)

--- a/src/main.c
+++ b/src/main.c
@@ -765,7 +765,7 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
                 vb_enter('n');
             }
 
-            WebKitWebFrame *frame     = webkit_web_view_get_main_frame(view);
+            WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
             dom_install_focus_blur_callbacks(webkit_web_frame_get_dom_document(frame));
             vb.state.done_loading_page = false;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1433,7 +1433,7 @@ static void onload_event_cb(WebKitWebView *view, WebKitWebFrame *frame,
     gpointer user_data)
 {
     Document *doc = webkit_web_frame_get_dom_document(frame);
-    dom_auto_insert_unless_strict_focus(doc);
+    dom_check_auto_insert(doc);
     vb.state.done_loading_page = true;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -752,6 +752,7 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
 
             /* clear possible set marks */
             marks_clear();
+
             break;
 
         case WEBKIT_LOAD_FIRST_VISUALLY_NON_EMPTY_LAYOUT:
@@ -764,8 +765,9 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
                 vb_enter('n');
             }
 
-            WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
-            dom_check_auto_insert(webkit_web_frame_get_dom_document(frame));
+            WebKitWebFrame *frame     = webkit_web_view_get_main_frame(view);
+            dom_install_focus_blur_callbacks(webkit_web_frame_get_dom_document(frame));
+            vb.state.done_loading_page = false;
 
             break;
 
@@ -1149,6 +1151,7 @@ static void setup_signals()
         "signal::should-show-delete-interface-for-element", G_CALLBACK(gtk_false), NULL,
         "signal::resource-request-starting", G_CALLBACK(webview_request_starting_cb), NULL,
         "signal::navigation-policy-decision-requested", G_CALLBACK(navigation_decision_requested_cb), NULL,
+        "signal::onload-event", G_CALLBACK(onload_event_cb), NULL,
         NULL
     );
 
@@ -1424,6 +1427,14 @@ static gboolean navigation_decision_requested_cb(WebKitWebView *view,
         return true;
     }
     return false;
+}
+
+static void onload_event_cb(WebKitWebView *view, WebKitWebFrame *frame,
+    gpointer user_data)
+{
+    Document *doc = webkit_web_frame_get_dom_document(frame);
+    dom_auto_insert_unless_strict_focus(doc);
+    vb.state.done_loading_page = true;
 }
 
 static void hover_link_cb(WebKitWebView *webview, const char *title, const char *link)

--- a/src/main.h
+++ b/src/main.h
@@ -315,6 +315,7 @@ typedef struct {
     char            *fifo_path;             /* holds the path to the control fifo */
     char            *socket_path;           /* holds the path to the control socket */
     char            *pid_str;               /* holds the pid as string */
+    gboolean        done_loading_page;
 } State;
 
 typedef struct {


### PR DESCRIPTION
Suppose you are opening a web page on which the focus is automatically
given to a text box. WebKit gives it the focus immediately after the
text box appears on the screen. However, the input mode is entered
only after the page has been completely loaded. Until then, the normal
mode is active, so keys are processed by it first. This isn't the
expected behavior, since one shouldn't have to wait for the completion
of loading if one can already see the text box and wants to type
something in it.
