### PR TITLE
Stop focus from appearing to be on input box after closing external editor

### DIFF
--- a/src/dom.c
+++ b/src/dom.c
@@ -78,6 +78,14 @@ void dom_clear_focus(WebKitWebView *view)
 }
 
 /**
+ * Give the focus to element.
+ */
+void dom_give_focus(Element *element)
+{
+    webkit_dom_element_focus(element);
+}
+
+/**
  * Find the first editable element and set the focus on it and enter input
  * mode.
  * Returns true if there was an editable element focused.

--- a/src/dom.h
+++ b/src/dom.h
@@ -35,6 +35,7 @@
 void dom_install_focus_blur_callbacks(Document *doc);
 void dom_check_auto_insert(Document *doc);
 void dom_clear_focus(WebKitWebView *view);
+void dom_give_focus(Element *element);
 gboolean dom_focus_input(Document *doc);
 gboolean dom_is_editable(Element *element);
 Element *dom_get_active_element(WebKitWebView *view);

--- a/src/input.c
+++ b/src/input.c
@@ -155,6 +155,7 @@ VbResult input_open_editor(void)
 
     /* disable the active element */
     dom_editable_element_set_disable(active, true);
+    dom_clear_focus(vb.gui.webview);
 
     EditorData *data = g_slice_new0(EditorData);
     data->file    = file_path;

--- a/src/input.c
+++ b/src/input.c
@@ -155,7 +155,6 @@ VbResult input_open_editor(void)
 
     /* disable the active element */
     dom_editable_element_set_disable(active, true);
-    dom_clear_focus(vb.gui.webview);
 
     EditorData *data = g_slice_new0(EditorData);
     data->file    = file_path;
@@ -177,6 +176,7 @@ static void resume_editor(GPid pid, int status, EditorData *data)
         g_free(text);
     }
     dom_editable_element_set_disable(data->element, false);
+    dom_give_focus(data->element);
 
     g_unlink(data->file);
     g_free(data->file);


### PR DESCRIPTION
Open a web page with a text box. Use ";e" to open the text box in an external editor. Close the external editor. There will be a blinking cursor in the text box, even though it is not focused. This patch seems to fix that behaviour.
