### PR TITLE
Do not blur the focused textbox after alt-tabbing.

### DIFF
--- a/src/dom.c
+++ b/src/dom.c
@@ -281,9 +281,10 @@ static gboolean auto_insert(Element *element)
 
 static gboolean editable_blur_cb(Element *element, Event *event)
 {
-    if (vb.mode->id == 'i') {
+    if (vb.state.window_has_focus && vb.mode->id == 'i') {
         vb_enter('n');
     }
+
     return false;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -66,6 +66,8 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec);
 static void webview_request_starting_cb(WebKitWebView *view,
     WebKitWebFrame *frame, WebKitWebResource *res, WebKitNetworkRequest *req,
     WebKitNetworkResponse *resp, gpointer data);
+static gboolean focus_out_event_cb(GtkWidget *widget, GdkEvent *event, gpointer user_data);
+static gboolean focus_in_event_cb(GtkWidget *widget, GdkEvent *event, gpointer user_data);
 static void destroy_window_cb(GtkWidget *widget);
 static void scroll_cb(GtkAdjustment *adjustment);
 static gboolean input_focus_in_cb(GtkWidget *widget, GdkEventFocus *event,
@@ -851,6 +853,20 @@ static void webview_request_starting_cb(WebKitWebView *view,
     }
 }
 
+static gboolean focus_out_event_cb(GtkWidget *widget, GdkEvent *event,
+    gpointer user_data)
+{
+    vb.state.window_has_focus = false;
+    return false;
+}
+
+static gboolean focus_in_event_cb(GtkWidget *widget, GdkEvent *event,
+    gpointer user_data)
+{
+    vb.state.window_has_focus = true;
+    return false;
+}
+
 static void destroy_window_cb(GtkWidget *widget)
 {
     vb_quit(true);
@@ -1159,7 +1175,8 @@ static void setup_signals()
         "signal::onload-event", G_CALLBACK(onload_event_cb), NULL,
         NULL
     );
-
+    g_signal_connect(vb.gui.window, "focus-in-event", G_CALLBACK(focus_in_event_cb), NULL);
+    g_signal_connect(vb.gui.window, "focus-out-event", G_CALLBACK(focus_out_event_cb), NULL);
 #ifdef FEATURE_ARH
     g_signal_connect(vb.session, "request-queued", G_CALLBACK(session_request_queued_cb), NULL);
 #endif

--- a/src/main.h
+++ b/src/main.h
@@ -316,6 +316,7 @@ typedef struct {
     char            *socket_path;           /* holds the path to the control socket */
     char            *pid_str;               /* holds the pid as string */
     gboolean        done_loading_page;
+    gboolean        window_has_focus;
 } State;
 
 typedef struct {


### PR DESCRIPTION
The focused textbox should still have the focus after the user switches to another window and then switches back to Vimb.