### PR TITLE
Install focus/blur callbacks when load finished

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -713,12 +713,12 @@ static void webview_download_progress_cb(WebKitWebView *view, GParamSpec *pspec)
 static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
 {
     const char *uri;
+    WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
 
     switch (webkit_web_view_get_load_status(view)) {
         case WEBKIT_LOAD_PROVISIONAL:
 #ifdef FEATURE_AUTOCMD
             {
-                WebKitWebFrame *frame     = webkit_web_view_get_main_frame(view);
                 WebKitWebDataSource *src  = webkit_web_frame_get_provisional_data_source(frame);
                 WebKitNetworkRequest *req = webkit_web_data_source_get_initial_request(src);
                 uri = webkit_network_request_get_uri(req);
@@ -737,7 +737,6 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
             autocmd_run(AU_LOAD_COMMITED, uri, NULL);
 #endif
             {
-                WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
                 JSContextRef ctx;
                 /* set the status */
                 if (g_str_has_prefix(uri, "https://")) {
@@ -781,14 +780,12 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
                 vb_enter('n');
             }
 
-            WebKitWebFrame *frame = webkit_web_view_get_main_frame(view);
             dom_install_focus_blur_callbacks(webkit_web_frame_get_dom_document(frame));
             vb.state.done_loading_page = false;
 
             break;
 
         case WEBKIT_LOAD_FINISHED:
-            frame = webkit_web_view_get_main_frame(view);
             dom_install_focus_blur_callbacks(webkit_web_frame_get_dom_document(frame));
             uri = webkit_web_view_get_uri(view);
 #ifdef FEATURE_AUTOCMD
@@ -809,7 +806,6 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
                 /* In case the requested uri could not be loaded the Current
                  * uri of the Webview would still be the PRevious one. So We
                  * use the provisional uri here. */
-                WebKitWebFrame *frame     = webkit_web_view_get_main_frame(view);
                 WebKitWebDataSource *src  = webkit_web_frame_get_provisional_data_source(frame);
                 if (src) {
                     WebKitNetworkRequest *req = webkit_web_data_source_get_initial_request(src);

--- a/src/main.c
+++ b/src/main.c
@@ -788,6 +788,8 @@ static void webview_load_status_cb(WebKitWebView *view, GParamSpec *pspec)
             break;
 
         case WEBKIT_LOAD_FINISHED:
+            frame = webkit_web_view_get_main_frame(view);
+            dom_install_focus_blur_callbacks(webkit_web_frame_get_dom_document(frame));
             uri = webkit_web_view_get_uri(view);
 #ifdef FEATURE_AUTOCMD
             autocmd_run(AU_LOAD_FINISHED, uri, NULL);


### PR DESCRIPTION
Looking into #214 I found that the focus/blur callbacks were not being set when fetching from the cache because the `WEBKIT_LOAD_FIRST_VISUALLY_NON_EMPTY_LAYOUT` status is skipped, going directly to `WEBKIT_LOAD_FINISHED`, so added the call to `dom_install_focus_blur_callbacks` there as well.

Not very familiar with this code and not sure if it's okay to be adding listeners twice (in non-cache situations), but anyway this is a starting point.