### PR TITLE
Small changes to build on OSX with macports

### DIFF
--- a/src/js2h.sh
+++ b/src/js2h.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo -n '#define HINTS_JS "'
+echo '#define HINTS_JS "' | tr -d '\n'
 cat $1 | \
     tr '\n\r\t' ' ' | \
     sed -e 's:/\*[^*]*\*/::g' \

--- a/src/main.h
+++ b/src/main.h
@@ -367,7 +367,7 @@ typedef struct {
     VbColor              status_bg[VB_STATUS_LAST];
     VbColor              status_fg[VB_STATUS_LAST];
     PangoFontDescription *status_font[VB_STATUS_LAST];
-} Style;
+} VbStyle;
 
 typedef struct {
     Gui             gui;
@@ -376,7 +376,7 @@ typedef struct {
     char            *files[FILES_LAST];
     Mode            *mode;
     Config          config;
-    Style           style;
+    VbStyle           style;
     SoupSession     *session;
 #ifdef HAS_GTK3
     Window          embed;


### PR DESCRIPTION
I built vimb on OSX Mavericks.

Steps to repro:

1. Install [macports](https://www.macports.org/install.php). Take note of the prefix (default is `/opt/local`).
1. Install vimb dependencies `sudo port install webkit-gtk3`. This takes hours.
1. Check out `vimb` https://github.com/fanglingsu/vimb/commit/c5b20658e84ae96c9945c1ca328813df8163aecc (last commit before switching to flock locking).
1. Apply the very small patch in this PR.
1. Build by telling `pkg-config` where to find the `vimb` dependencies:

    ```sh
    env PKG_CONFIG_PATH=${MACPORTS_PREFIX?}/lib/pkgconfig make
    ```

    If you have trouble with the library version conditional logic in `config.mk`, apply [this patch](https://gist.github.com/plredmond/c57bed437da15de6e4e5).
1. Feel vimb zen.

![screen shot 2015-11-17 at 10 50 44](https://cloud.githubusercontent.com/assets/1078772/11221428/eea9e0ee-8d19-11e5-8984-21c183d34948.png)
