### PR TITLE
Added closed-max-items option

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1023,6 +1023,10 @@ Automatically shrink standalone images to fit.
 .B caret (bool)
 Whether to enable accessibility enhanced keyboard navigation.
 .TP
+.B closed-max-items (int)
+Maximum number of stored last closed browser windows. If closed-max-items is
+set to 0, closed browser windows will not be stored.
+.TP
 .B cursivfont (string)
 The font family used as the default for content using cursive font.
 .TP
@@ -1537,7 +1541,7 @@ Configuration file to set WebKit setting, some GUI styles and keybindings.
 Cookie store file.
 .TP
 .I closed
-Holds the URI of the last closed browser window.
+Holds the URI of last closed browser windows.
 .TP
 .I history
 This file holds the history of unique opened URIs.

--- a/src/bookmark.c
+++ b/src/bookmark.c
@@ -215,29 +215,7 @@ gboolean bookmark_queue_unshift(const char *uri)
  */
 char *bookmark_queue_pop(int *item_count)
 {
-    int len, i;
-    char **lines, *uri = NULL;
-
-    lines = util_get_lines(vb.files[FILES_QUEUE]);
-    if (lines && (len = g_strv_length(lines))) {
-        GString *new = g_string_new(NULL);
-
-        uri = g_strdup(lines[0]);
-        /* don't process last empty line */
-        len -= 1;
-        /* skip the first list that should be removed */
-        for (i = 1; i < len; i++) {
-            g_string_append_printf(new, "%s\n", lines[i]);
-        }
-        g_strfreev(lines);
-        g_file_set_contents(vb.files[FILES_QUEUE], new->str, -1, NULL);
-        g_string_free(new, true);
-
-        *item_count = len - 1;
-    } else {
-        *item_count = 0;
-    }
-    return uri;
+    return util_file_pop_line(vb.files[FILES_QUEUE], item_count);
 }
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -598,8 +598,20 @@ void vb_quit(gboolean force)
     webkit_web_view_stop_loading(vb.gui.webview);
 
     /* write last URL into file for recreation */
-    if (vb.state.uri) {
-        g_file_set_contents(vb.files[FILES_CLOSED], vb.state.uri, -1, NULL);
+    if (vb.state.uri && vb.config.closed_max) {
+        char **lines = util_get_lines(vb.files[FILES_CLOSED]);
+        GString *new = g_string_new(vb.state.uri);
+        g_string_append(new, "\n");
+        if (lines) {
+            int len = g_strv_length(lines);
+            int i;
+            for (i = 0; i < len - 1 && i < vb.config.closed_max - 1; i++) {
+                g_string_append_printf(new, "%s\n", lines[i]);
+            }
+            g_strfreev(lines);
+        }
+        g_file_set_contents(vb.files[FILES_CLOSED], new->str, -1, NULL);
+        g_string_free(new, true);
     }
 
     gtk_main_quit();

--- a/src/main.h
+++ b/src/main.h
@@ -323,6 +323,7 @@ typedef struct {
     int          scrollstep;
     char         *download_dir;
     guint        history_max;
+    guint        closed_max;
     guint        timeoutlen;       /* timeout for ambiguous mappings */
     gboolean     strict_focus;
     GHashTable   *headers;         /* holds user defined header appended to requests */

--- a/src/normal.c
+++ b/src/normal.c
@@ -602,12 +602,19 @@ static VbResult normal_open_clipboard(const NormalCmdInfo *info)
 
 static VbResult normal_open(const NormalCmdInfo *info)
 {
+    char *uri;
     Arg a;
+
+    uri = util_file_pop_line(vb.files[FILES_CLOSED], NULL);
+    if (!uri) {
+        return RESULT_ERROR;
+    }
+
     /* open last closed */
     a.i = info->key == 'U' ? VB_TARGET_NEW : VB_TARGET_CURRENT;
-    a.s = util_get_file_contents(vb.files[FILES_CLOSED], NULL);
+    a.s = uri;
     vb_load_uri(&a);
-    g_free(a.s);
+    g_free(uri);
 
     return RESULT_COMPLETE;
 }

--- a/src/setting.c
+++ b/src/setting.c
@@ -208,6 +208,8 @@ void setting_init()
     setting_add("download-path", TYPE_CHAR, &"", internal, 0, &vb.config.download_dir);
     i = 2000;
     setting_add("history-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.history_max);
+    i = 10;
+    setting_add("closed-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.closed_max);
     setting_add("editor-command", TYPE_CHAR, &"x-terminal-emulator -e -vi '%s'", NULL, 0, NULL);
     setting_add("header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, NULL);
 #ifdef FEATURE_ARH

--- a/src/util.c
+++ b/src/util.c
@@ -273,6 +273,40 @@ gboolean util_file_prepend(const char *file, const char *format, ...)
     return res;
 }
 
+/**
+ * Retrieves the first line from file and delete it from file.
+ *
+ * @file:       file to read from
+ * @item_count: will be filled with the number of remaining lines in file if it
+ *              is not NULL.
+ *
+ * Returned string must be freed with g_free.
+ */
+char *util_file_pop_line(const char *file, int *item_count)
+{
+    char **lines = util_get_lines(file);
+    char *line = NULL;
+    int count = 0;
+
+    if (lines) {
+        int len = g_strv_length(lines);
+        if (len) {
+            line = g_strdup(lines[0]);
+            /* minus one for last empty item and one for popped item */
+            count = len - 2;
+            char *new = g_strjoinv("\n", lines + 1);
+            g_file_set_contents(file, new, -1, NULL);
+            g_free(new);
+        }
+        g_strfreev(lines);
+    }
+
+    if (item_count) {
+        *item_count = count;
+    }
+    return line;
+}
+
 char *util_strcasestr(const char *haystack, const char *needle)
 {
     guchar c1, c2;

--- a/src/util.h
+++ b/src/util.h
@@ -42,6 +42,7 @@ GList *util_file_to_unique_list(const char *filename, Util_Content_Func func,
     guint max_items);
 gboolean util_file_append(const char *file, const char *format, ...);
 gboolean util_file_prepend(const char *file, const char *format, ...);
+char *util_file_pop_line(const char *file, int *item_count);
 char* util_strcasestr(const char* haystack, const char* needle);
 char *util_str_replace(const char* search, const char* replace, const char* string);
 gboolean util_create_tmp_file(const char *content, char **file);


### PR DESCRIPTION
This option controls how many closed pages will be saved. Previously only 1 item is saved. It can also be set to 0 to disable saving closed pages.

Note that the behavior now is different from the previous one. Previously the `closed` file is not cleared when reopening the page, so it is possible to reopen the page several times. Now pages are only reopened once.