### PR TITLE
Use the beginning position of links for hinting

### DIFF
--- a/src/hints.js
+++ b/src/hints.js
@@ -90,8 +90,8 @@ Object.freeze((function(){
                 }
                 var rect = e.getBoundingClientRect();
                 if (!rect ||
-                    rect.top > offsets.bottom || rect.bottom < offsets.top ||
-                    rect.left > offsets.right || rect.right < offsets.left
+                    rect.top >= offsets.bottom || rect.bottom <= offsets.top ||
+                    rect.left >= offsets.right || rect.right <= offsets.left
                 ) {
                     return false;
                 }
@@ -137,7 +137,7 @@ Object.freeze((function(){
                 count++;
 
                 /* create the hint label with number */
-                rect  = e.getBoundingClientRect();
+                rect  = e.getClientRects()[0];
                 label = labelTmpl.cloneNode(false);
                 label.setAttribute(
                     "style", [


### PR DESCRIPTION
Previously the top-left corner is used for creating hints. For links that span over several lines this is usually not the beginning of text. If there is another link at the beginning of this line, the two hints will be in the same place, making one of them hard to see.

I also changed the comparison logic in `isVisible`, because having 0 pixel visible should not be considered visible. It is included here because `getBoundingClientRect` will return (0,0,0,0) when `getClientRects` is empty, which was not caught in the `isVisible` check. This should also fix some hints appearing in top-left corner when no hintable elements are there.
