### PR TITLE
Feature: set initial default zoom via config

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1295,6 +1295,9 @@ The value `0' convert all cookies as session-only cookies
 Any other value enforce the expire-time (the expire-time value will be the
 lower between server-side request and time defined with `cookie-expire-time').
 .TP
+.B default-zoom (int)
+Initial Full-Content Zoom in percent. Default is 100.
+.TP
 .B download-command (string)
 A command with placeholder '%s' that will be invoked to download a URI.
 .RS

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -50,6 +50,8 @@
 #define FEATURE_HSTS
 /* enable soup caching - size can be configure by maximum-cache-size setting */
 #define FEATURE_SOUP_CACHE
+/* allow setting default_zoom via config */
+#define FEATURE_DEFAULT_ZOOM
 /* enable the :autocmd feature */
 #define FEATURE_AUTOCMD
 /* enable the :auto-response-header feature */

--- a/src/main.c
+++ b/src/main.c
@@ -1134,19 +1134,26 @@ static void init_core(void)
     }
 
 #ifdef FEATURE_HIGH_DPI
-    /* fix for high dpi displays */
-    GdkScreen *screen = gdk_window_get_screen(gtk_widget_get_window(vb.gui.window));
-    gdouble dpi = gdk_screen_get_resolution(screen);
-    if (dpi != -1) {
-        WebKitWebSettings *setting = webkit_web_view_get_settings(gui->webview);
-        webkit_web_view_set_full_content_zoom(gui->webview, true);
-        g_object_set(G_OBJECT(setting), "enforce-96-dpi", true, NULL);
+#ifdef FEATURE_DEFAULT_ZOOM
+    /* if default_zoom was not changed via config */
+    if (vb.config.default_zoom == 1.0) {
+#endif
+        /* fix for high dpi displays */
+        GdkScreen *screen = gdk_window_get_screen(gtk_widget_get_window(vb.gui.window));
+        gdouble dpi = gdk_screen_get_resolution(screen);
+        if (dpi != -1) {
+            WebKitWebSettings *setting = webkit_web_view_get_settings(gui->webview);
+            webkit_web_view_set_full_content_zoom(gui->webview, true);
+            g_object_set(G_OBJECT(setting), "enforce-96-dpi", true, NULL);
 
-        /* calculate the zoom level based on 96 dpi */
-        vb.config.default_zoom = dpi/96;
+            /* calculate the zoom level based on 96 dpi */
+            vb.config.default_zoom = dpi/96;
 
-        webkit_web_view_set_zoom_level(gui->webview, vb.config.default_zoom);
+            webkit_web_view_set_zoom_level(gui->webview, vb.config.default_zoom);
+        }
+#ifdef FEATURE_DEFAULT_ZOOM
     }
+#endif
 #endif
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1133,8 +1133,6 @@ static void init_core(void)
         g_object_set(G_OBJECT(setting), "enable-default-context-menu", false, NULL);
     }
 
-    vb.config.default_zoom = 1.0;
-
 #ifdef FEATURE_HIGH_DPI
     /* fix for high dpi displays */
     GdkScreen *screen = gdk_window_get_screen(gtk_widget_get_window(vb.gui.window));

--- a/src/setting.c
+++ b/src/setting.c
@@ -90,6 +90,9 @@ static int hsts(const char *name, int type, void *value, void *data);
 #ifdef FEATURE_SOUP_CACHE
 static int soup_cache(const char *name, int type, void *value, void *data);
 #endif
+#ifdef FEATURE_DEFAULT_ZOOM
+static int default_zoom(const char *name, int type, void *value, void *data);
+#endif
 static gboolean validate_js_regexp_list(const char *pattern);
 
 void setting_init()
@@ -228,6 +231,11 @@ void setting_init()
     setting_add("maximum-cache-size", TYPE_INTEGER, &i, soup_cache, 0, NULL);
 #endif
     setting_add("x-hint-command", TYPE_CHAR, &":o <C-R>;", NULL, 0, NULL);
+
+#ifdef FEATURE_DEFAULT_ZOOM
+    i = 100;
+    setting_add("default_zoom", TYPE_INTEGER, &i, default_zoom, 0, &vb.config.default_zoom);
+#endif
 
     /* initialize the shortcuts and set the default shortcuts */
     shortcut_init();
@@ -901,6 +909,18 @@ static int soup_cache(const char *name, int type, void *value, void *data)
     if (!kilobytes) {
         soup_cache_clear(vb.config.soup_cache);
     }
+    return VB_CMD_SUCCESS;
+}
+#endif
+
+#ifdef FEATURE_DEFAULT_ZOOM
+static int default_zoom(const char *name, int type, void *value, void *data)
+{
+    *(float*)data = (float)*(int*)value / 100.0;
+
+    webkit_web_view_set_full_content_zoom(vb.gui.webview, true);
+    webkit_web_view_set_zoom_level(vb.gui.webview, vb.config.default_zoom);
+
     return VB_CMD_SUCCESS;
 }
 #endif

--- a/src/setting.c
+++ b/src/setting.c
@@ -234,7 +234,7 @@ void setting_init()
 
 #ifdef FEATURE_DEFAULT_ZOOM
     i = 100;
-    setting_add("default_zoom", TYPE_INTEGER, &i, default_zoom, 0, &vb.config.default_zoom);
+    setting_add("default-zoom", TYPE_INTEGER, &i, default_zoom, 0, &vb.config.default_zoom);
 #endif
 
     /* initialize the shortcuts and set the default shortcuts */


### PR DESCRIPTION
This feature adds a new configuration value:

`default-zoom` This value represents the initial Full-Content Zoom level in percent. Default is 100.

So you are able to scale content up or down by default, without pressing `zI`/`zO`.

I implemented this feature for all those who:
 - need a bit more size to please their eyes
 - have a hard time configuring their high resolution monitor setup properly :)

Hope this might help someone.