### PR TITLE
Feature/webkit2 dot desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ install: vimb
 	# @sed -e "s!VERSION!$(VERSION)!g" \
 		# -e "s!PREFIX!$(PREFIX)!g" \
 		# -e "s!DATE!`date +'%m %Y'`!g" $(DOCDIR)/vimb.1 > $(MANPREFIX)/man1/vimb.1
+	@# .desktop file
+	install -d $(DOTDESKTOPPREFIX)
+	install -m 644 vimb.desktop $(DOTDESKTOPPREFIX)/vimb.desktop
 
 uninstall:
 	$(RM) $(BINPREFIX)/vimb $(DESTDIR)$(MANDIR)/man1/vimb.1 $(EXTPREFIX)/$(EXTTARGET)

--- a/config.mk
+++ b/config.mk
@@ -1,11 +1,12 @@
 VERSION = dev-3.0
 
-PREFIX         ?= /usr/local
-BINPREFIX      := $(DESTDIR)$(PREFIX)/bin
-MANPREFIX      := $(DESTDIR)$(PREFIX)/share/man
-EXAMPLEPREFIX  := $(DESTDIR)$(PREFIX)/share/vimb/example
-RUNPREFIX      := $(PREFIX)
-EXTPREFIX      := $(RUNPREFIX)/lib/vimb
+PREFIX           ?= /usr/local
+BINPREFIX        := $(DESTDIR)$(PREFIX)/bin
+MANPREFIX        := $(DESTDIR)$(PREFIX)/share/man
+EXAMPLEPREFIX    := $(DESTDIR)$(PREFIX)/share/vimb/example
+DOTDESKTOPPREFIX := $(DESTDIR)$(PREFIX)/share/applications
+RUNPREFIX        := $(PREFIX)
+EXTPREFIX        := $(RUNPREFIX)/lib/vimb
 
 # define some directories
 SRCDIR  = src

--- a/vimb.desktop
+++ b/vimb.desktop
@@ -1,0 +1,11 @@
+# Based on Arch Linux' chromium.desktop
+[Desktop Entry]
+Name=vimb
+GenericName=Web Browser
+Comment=Access the Internet
+Exec=vimb %U
+Terminal=false
+Icon=
+Type=Application
+Categories=GTK;Network;WebBrowser;
+MimeType=text/html;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;


### PR DESCRIPTION
Adds a `.desktop` file for vimb.

This allows to set vimb as default browser using `xdg-utils` or similar.
