### PR TITLE
Fix/webkit2 readme cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ project directory.
   - [ ] completion
   - [ ] HSTS
   - [ ] auto-response-header
-  - [ ] cookies support
+  - [x] cookies support
   - [ ] register support and `:register` command
   - [ ] read it later queue
   - [ ] show scroll indicator in statusbar as top, x%, bttom or all


### PR DESCRIPTION
Marks cookie support as done in the  README file. It's implemented and working, apparently. Or is there anything still pending?