### PR TITLE
Fix/webkit2 readme register support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ project directory.
   - [ ] HSTS
   - [ ] auto-response-header
   - [ ] cookies support
-  - [ ] register support and `:register` command
+  - [x] register support and `:register` command
   - [ ] read it later queue
   - [ ] show scroll indicator in statusbar as top, x%, bttom or all
         how can we get this information from webview easily?


### PR DESCRIPTION
Marks register support as done in the README file. Appently working.

Or is there anything missing with regard to this feature?