### PR TITLE
Feature: webkit2 downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ project directory.
   - [ ] kiosk-mode `--kiosk,-k`
   - [ ] allow to start vimb reading html from `stdin` by `vimb -`
   - [ ] browser modes normal, input, command, pass-through and hintmode
-  - [ ] download support
+  - [x] download support
   - [ ] editor command
   - [ ] external downloader
   - [ ] hinting

--- a/src/main.h
+++ b/src/main.h
@@ -213,7 +213,7 @@ struct Client {
     struct Statusbar    statusbar;
     void                *comp;                  /* pointer to data used in completion.c */
     Mode                *mode;                  /* current active browser mode */
-    WebKitWebContext    *webctx;
+    /* WebKitWebContext    *webctx; */          /* not used atm, use webkit_web_context_get_default() instead */
     GtkWidget           *window, *input;
     WebKitWebView       *webview;
     guint64             page_id;                /* page id of the webview */

--- a/src/setting.c
+++ b/src/setting.c
@@ -140,6 +140,7 @@ void setting_init(Client *c)
     setting_add(c, "fullscreen", TYPE_BOOLEAN, &off, fullscreen, 0, NULL);
     i = 100;
     setting_add(c, "default-zoom", TYPE_INTEGER, &i, default_zoom, 0, NULL);
+    setting_add(c, "download-path", TYPE_CHAR, &"~", NULL, 0, NULL);
 
     /* initialize the shortcuts and set the default shortcuts */
     shortcut_init(c);


### PR DESCRIPTION
This implements some convenience wrapping around webkit's file downloading functionality

 * Configure a download path via settings (`~` and env vars supported)
 * Name unnamed download files
 * Ensure unique filenames by inserting a numerical suffix at a sane position
 * Track downloads in client state
 * Do not quit if downloads are running
 * Report download success and failures via status bar