### PR TITLE
Fix/webkit2 config.h auto update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ options:
 	@echo "LDFLAGS = $(LDFLAGS)"
 	@echo "CC      = $(CC)"
 
-vimb: $(SUBDIRS:%=%.subdir-all)
+$(SRCDIR)/config.h: $(SRCDIR)/config.def.h
+	@cp $@ $@.`date +%Y%m%d%H%M%S`
+	@cp $< $@
+
+vimb: $(SRCDIR)/config.h $(SUBDIRS:%=%.subdir-all)
 
 %.subdir-all:
 	@$(MAKE) $(MFLAGS) -C $*

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 config.h
+config.h.*
 vimb


### PR DESCRIPTION
This patch adds a `make` rule to automatically update `config.h` if `config.def.h` changed. As user changes in `config.h` will be overwritten this way, a backup of the previous `config.h` is created.
