### PR TITLE
Feature/webkit2 gui style settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ project directory.
   - [ ] try to use the webkit2 feature of running multiple pages with related
         view instance `webkit_web_view_new_with_related_view`
   - [ ] allow setting of different scopes, global and instance (new feature)
-  - [ ] remove the settings related to the gui like `status-color-bg` this was
+  - [x] remove the settings related to the gui like `status-color-bg` this was
         only a hack and is not recommended for new gtk3 applications. the
         color and font settings should be setup by css instead.
   - [ ] webkit2 does not provide the view mode `source` so maybe this is going

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -26,6 +26,8 @@
 #define FEATURE_TITLE_PROGRESS
 /* show page title in url completions */
 #define FEATURE_TITLE_IN_COMPLETION
+/* support gui style settings compatible with vimb2 */
+#define FEATURE_GUI_STYLE_VIMB2_COMPAT
 
 #ifdef FEATURE_WGET_PROGRESS_BAR
 /* chars to use for the progressbar */
@@ -39,16 +41,8 @@
 
 /* number of chars to be shown in statusbar for ambiguous commands */
 #define SHOWCMD_LEN                 10
-/* css applied to the gui elements of the borwser window */
-#define GUI_STYLE                   "\
-#statusbar{color:#fff;background-color:#000;font:monospace bold 10;} \
-#statusbar.secure{background-color:#95e454;color:#000;} \
-#statusbar.insecure{background-color:#f77;color:#000;} \
-#input{background-color:#fff;color:#000;font:monospace 10;} \
-#input.error{background-color:#f77;font-weight:bold;} \
-#completion{color:#fff;background-color:#656565;font:monospace 10;} \
-#completion:hover{background-color:#777;} \
-#completion:selected{color:#f6f3e8;background-color:#888;}"
+/* css applied to the gui elements regardless of user's settings */
+#define GUI_STYLE_CSS_BASE          "#input text{background-color:inherit;color:inherit;caret-color:@color;font:inherit;}"
 
 /* default font size for fonts in webview */
 #define SETTING_DEFAULT_FONT_SIZE   10

--- a/src/main.h
+++ b/src/main.h
@@ -275,5 +275,6 @@ void vb_quit(Client *c, gboolean force);
 void vb_register_add(Client *c, char buf, const char *value);
 const char *vb_register_get(Client *c, char buf);
 void vb_statusbar_update(Client *c);
+void vb_gui_style_update(Client *c, const char *name, const char *value);
 
 #endif /* end of include guard: _MAIN_H */

--- a/src/setting.c
+++ b/src/setting.c
@@ -51,6 +51,7 @@ static void setting_free(Setting *s);
 static int cookie_accept(Client *c, const char *name, DataType type, void *value, void *data);
 static int default_zoom(Client *c, const char *name, DataType type, void *value, void *data);
 static int fullscreen(Client *c, const char *name, DataType type, void *value, void *data);
+static int gui_style(Client *c, const char *name, DataType type, void *value, void *data);
 static int input_autohide(Client *c, const char *name, DataType type, void *value, void *data);
 static int internal(Client *c, const char *name, DataType type, void *value, void *data);
 static int headers(Client *c, const char *name, DataType type, void *value, void *data);
@@ -141,6 +142,40 @@ void setting_init(Client *c)
     i = 100;
     setting_add(c, "default-zoom", TYPE_INTEGER, &i, default_zoom, 0, NULL);
     setting_add(c, "download-path", TYPE_CHAR, &"~", NULL, 0, NULL);
+
+#ifdef FEATURE_GUI_STYLE_VIMB2_COMPAT
+    /* gui style settings vimb2 compatibility */
+    setting_add(c, "completion-bg-active", TYPE_CHAR, &"#888", gui_style, 0, NULL);
+    setting_add(c, "completion-bg-normal", TYPE_CHAR, &"#656565", gui_style, 0, NULL);
+    setting_add(c, "completion-fg-active", TYPE_CHAR, &"#f6f3e8", gui_style, 0, NULL);
+    setting_add(c, "completion-fg-normal", TYPE_CHAR, &"#fff", gui_style, 0, NULL);
+    setting_add(c, "completion-font", TYPE_CHAR, &"monospace 10", gui_style, 0, NULL);
+    setting_add(c, "input-bg-error", TYPE_CHAR, &"#f77", gui_style, 0, NULL);
+    setting_add(c, "input-bg-normal", TYPE_CHAR, &"#fff", gui_style, 0, NULL);
+    setting_add(c, "input-fg-error", TYPE_CHAR, &"#000", gui_style, 0, NULL);
+    setting_add(c, "input-fg-normal", TYPE_CHAR, &"#000", gui_style, 0, NULL);
+    setting_add(c, "input-font-error", TYPE_CHAR, &"monospace bold 10", gui_style, 0, NULL);
+    setting_add(c, "input-font-normal", TYPE_CHAR, &"monospace 10", gui_style, 0, NULL);
+    setting_add(c, "status-color-bg", TYPE_CHAR, &"#000", gui_style, 0, NULL);
+    setting_add(c, "status-color-fg", TYPE_CHAR, &"#fff", gui_style, 0, NULL);
+    setting_add(c, "status-font", TYPE_CHAR, &"monospace bold 10", gui_style, 0, NULL);
+    setting_add(c, "status-ssl-color-bg", TYPE_CHAR, &"#95e454", gui_style, 0, NULL);
+    setting_add(c, "status-ssl-color-fg", TYPE_CHAR, &"#000", gui_style, 0, NULL);
+    setting_add(c, "status-ssl-font", TYPE_CHAR, &"", gui_style, 0, NULL);
+    setting_add(c, "status-sslinvalid-color-bg", TYPE_CHAR, &"#f77", gui_style, 0, NULL);
+    setting_add(c, "status-sslinvalid-color-fg", TYPE_CHAR, &"#000", gui_style, 0, NULL);
+    setting_add(c, "status-sslinvalid-font", TYPE_CHAR, &"", gui_style, 0, NULL);
+#else
+    /* gui style settings vimb3 */
+    setting_add(c, "completion-css", TYPE_CHAR, &"color:#fff;background-color:#656565;font:monospace 10;", gui_style, 0, NULL);
+    setting_add(c, "completion-hover-css", TYPE_CHAR, &"background-color:#777;", gui_style, 0, NULL);
+    setting_add(c, "completion-selected-css", TYPE_CHAR, &"color:#f6f3e8;background-color:#888;", gui_style, 0, NULL);
+    setting_add(c, "input-css", TYPE_CHAR, &"background-color:#fff;color:#000;font:monospace 10;", gui_style, 0, NULL);
+    setting_add(c, "input-error-css", TYPE_CHAR, &"background-color:#f77;font-weight:bold;", gui_style, 0, NULL);
+    setting_add(c, "status-css", TYPE_CHAR, &"color:#fff;background-color:#000;font:monospace bold 10;", gui_style, 0, NULL);
+    setting_add(c, "status-ssl-css", TYPE_CHAR, &"background-color:#95e454;color:#000;", gui_style, 0, NULL);
+    setting_add(c, "status-sslinvalid-css", TYPE_CHAR, &"background-color:#f77;color:#000;", gui_style, 0, NULL);
+#endif /* FEATURE_GUI_STYLE_VIMB2_COMPAT */
 
     /* initialize the shortcuts and set the default shortcuts */
     shortcut_init(c);
@@ -609,6 +644,13 @@ static int user_style(Client *c, const char *name, DataType type, void *value, v
 static int statusbar(Client *c, const char *name, DataType type, void *value, void *data)
 {
     gtk_widget_set_visible(GTK_WIDGET(c->statusbar.box), *(gboolean*)value);
+
+    return CMD_SUCCESS;
+}
+
+static int gui_style(Client *c, const char *name, DataType type, void *value, void *data)
+{
+    vb_gui_style_update(c, name, (const char*)value);
 
     return CMD_SUCCESS;
 }


### PR DESCRIPTION
This patch implements CSS GUI style settings on the `webkit2` branch.

Via `config.h`, two modes can be selected:
 * **vimb2 compatibility** (current default) to still allow vimb2 config files to work properly, very handy on machines where vimb2 is in production and vimb3 is in development
 * **vimb3** with less settings and more freedom, where each setting holds the complete css string for a GUI element in a certain state

Later, the vimb2 compatibility mode could be removed - for vimb3 release for example.