### PR TITLE
Allow conditional compilation of xembed

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -845,7 +845,7 @@ feature and started with `--socket' option.
 .TP
 .B VIMB_XID
 Holds the X-Window id of the Vimb window or of the embedding window if Vimb is
-started with the -e option.
+compiled with XEMBED and started with the -e option.
 .PD
 .PP
 Example:

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -28,6 +28,8 @@
 #define FEATURE_SEARCH_HIGHLIGHT
 /* disable scrollbars */
 #define FEATURE_NO_SCROLLBARS
+/* disable X window embedding */
+/* #define FEATURE_NO_XEMBED */
 /* show page title in url completions */
 #define FEATURE_TITLE_IN_COMPLETION
 /* enable the read it later queue */

--- a/src/main.h
+++ b/src/main.h
@@ -27,9 +27,11 @@
 #include <JavaScriptCore/JavaScript.h>
 #include <fcntl.h>
 #include <stdio.h>
+#ifndef FEATURE_NO_XEMBED
 #ifdef HAS_GTK3
 #include <gdk/gdkx.h>
 #include <gtk/gtkx.h>
+#endif
 #endif
 #include "config.h"
 #ifdef FEATURE_HSTS
@@ -373,10 +375,12 @@ typedef struct {
     Config          config;
     VbStyle           style;
     SoupSession     *session;
+#ifndef FEATURE_NO_XEMBED
 #ifdef HAS_GTK3
     Window          embed;
 #else
     GdkNativeWindow embed;
+#endif
 #endif
     GHashTable      *modes; /* all available browser main modes */
 } VbCore;


### PR DESCRIPTION
In order to make use of the xembed feature, we require
functionality native to the X11 windowing environment in order to
get a window's X identifier. Obviously, this requires us to
compile with a Gtk+ library which has support for X, restricting
us from working on Wayland-only platforms.

The issue can be fixed by making the Xembed feature optional. As
it is the only feature requiring platform-specific features, this
neatly allows us to build for a Wayland-only platform when XEMBED
is disabled.