### PR TITLE
fix path expansion to accept valid POSIX usernames

### DIFF
--- a/src/ascii.h
+++ b/src/ascii.h
@@ -60,16 +60,17 @@ static const unsigned char chartable[256] = {
 #undef C
 #undef SC
 
-#define VB_IS_UPPER(c)     ((chartable[(unsigned char)c] & VB_UPPER) != 0)
-#define VB_IS_LOWER(c)     ((chartable[(unsigned char)c] & VB_LOWER) != 0)
-#define VB_IS_DIGIT(c)     ((chartable[(unsigned char)c] & VB_DIGIT) != 0)
-#define VB_IS_PUNKT(c)     ((chartable[(unsigned char)c] & VB_PUNKT) != 0)
-#define VB_IS_SPACE(c)     ((chartable[(unsigned char)c] & VB_SPACE) != 0)
-#define VB_IS_CTRL(c)      ((chartable[(unsigned char)c] & VB_CTRL) != 0)
-#define VB_IS_SEPARATOR(c) (VB_IS_SPACE(c) || c == '"' || c == '\'')
-#define VB_IS_ALPHA(c)     (VB_IS_LOWER(c) || VB_IS_UPPER(c))
-#define VB_IS_ALNUM(c)     (VB_IS_ALPHA(c) || VB_IS_DIGIT(c))
-#define VB_IS_IDENT(c)     (VB_IS_ALNUM(c) || c == '_')
+#define VB_IS_UPPER(c)      ((chartable[(unsigned char)c] & VB_UPPER) != 0)
+#define VB_IS_LOWER(c)      ((chartable[(unsigned char)c] & VB_LOWER) != 0)
+#define VB_IS_DIGIT(c)      ((chartable[(unsigned char)c] & VB_DIGIT) != 0)
+#define VB_IS_PUNKT(c)      ((chartable[(unsigned char)c] & VB_PUNKT) != 0)
+#define VB_IS_SPACE(c)      ((chartable[(unsigned char)c] & VB_SPACE) != 0)
+#define VB_IS_CTRL(c)       ((chartable[(unsigned char)c] & VB_CTRL) != 0)
+#define VB_IS_SEPARATOR(c)  (VB_IS_SPACE(c) || c == '"' || c == '\'')
+#define VB_IS_ALPHA(c)      (VB_IS_LOWER(c) || VB_IS_UPPER(c))
+#define VB_IS_ALNUM(c)      (VB_IS_ALPHA(c) || VB_IS_DIGIT(c))
+#define VB_IS_IDENT(c)      (VB_IS_ALNUM(c) || c == '_')
+#define VB_IS_USER_IDENT(c) (VB_IS_IDENT(c) || c == '-' || c == '.')
 
 /* CSI (control sequence introducer) is the first byte of a control sequence
  * and is always followed by two bytes. */

--- a/src/util.c
+++ b/src/util.c
@@ -489,12 +489,12 @@ gboolean util_parse_expansion(const char **input, GString *str, int flags,
             if (!*(*input + 1) || VB_IS_SPACE(*(*input + 1))) {
                 (*input)++;
             }
-        } else {
+        } else if (**input != '-') {
             /* look ahead to / space or end of string to get a possible
              * username for ~user pattern */
             name = g_string_new("");
             /* current char is ~ that is skipped to get the user name */
-            while (VB_IS_IDENT(**input)) {
+	    while (VB_IS_USER_IDENT(**input)) {
                 g_string_append_c(name, **input);
                 (*input)++;
             }


### PR DESCRIPTION
To be portable across systems conforming to POSIX.1-2008, the
username is composed of characters from the portable filename character
set([A-Za-z._-])[1][2].

The <hyphen-minus> character should not be used as the first
character of a portable user name.

Links:
[1] Username format:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_435

[2] Portable filename character set:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282