### PR TITLE
Webkit2 font size improvements

### DIFF
--- a/src/config.def.h
+++ b/src/config.def.h
@@ -47,6 +47,6 @@
 /* default font size for fonts in webview */
 #define SETTING_DEFAULT_FONT_SIZE             16
 #define SETTING_DEFAULT_MONOSPACE_FONT_SIZE   13
-#define SETTING_GUI_FONT_NORMAL     "10px monospace"
-#define SETTING_GUI_FONT_EMPH       "bold 10px monospace"
-#define SETTING_HOME_PAGE           "about:blank"
+#define SETTING_GUI_FONT_NORMAL               "10pt monospace"
+#define SETTING_GUI_FONT_EMPH                 "bold 10pt monospace"
+#define SETTING_HOME_PAGE                     "about:blank"

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -45,7 +45,8 @@
 #define GUI_STYLE_CSS_BASE          "#input text{background-color:inherit;color:inherit;caret-color:@color;font:inherit;}"
 
 /* default font size for fonts in webview */
-#define SETTING_DEFAULT_FONT_SIZE   10
+#define SETTING_DEFAULT_FONT_SIZE             16
+#define SETTING_DEFAULT_MONOSPACE_FONT_SIZE   13
 #define SETTING_GUI_FONT_NORMAL     "10px monospace"
 #define SETTING_GUI_FONT_EMPH       "bold 10px monospace"
 #define SETTING_HOME_PAGE           "about:blank"

--- a/src/setting.c
+++ b/src/setting.c
@@ -102,7 +102,7 @@ void setting_init(Client *c)
     i = 5;
     setting_add(c, "minimumfontsize", TYPE_INTEGER, &i, webkit, 0, "minimum-font-size");
     setting_add(c, "monofont", TYPE_CHAR, &"monospace", webkit, 0, "monospace-font-family");
-    i = SETTING_DEFAULT_FONT_SIZE;
+    i = SETTING_DEFAULT_MONOSPACE_FONT_SIZE;
     setting_add(c, "monofontsize", TYPE_INTEGER, &i, webkit, 0, "default-monospace-font-size");
     setting_add(c, "offlinecache", TYPE_BOOLEAN, &on, webkit, 0, "enable-offline-web-application-cache");
     setting_add(c, "plugins", TYPE_BOOLEAN, &on, webkit, 0, "enable-plugins");


### PR DESCRIPTION
This changes aim to make the default font size settings look prettier and better match common settings know from vimb2 and other browsers.

1. The GTK GUI font size is now set to 10pt instead of 10px, so the GUI looks more similar to vimb2
2. The WebKIT2 default font and default monospace font sizes are now set to 16 and 13 respectively (the WebKIT2 defaults [1] [2])

[1] https://lazka.github.io/pgi-docs/WebKit2-4.0/classes/Settings.html#WebKit2.Settings.props.default_font_size
[2] https://lazka.github.io/pgi-docs/WebKit2-4.0/classes/Settings.html#WebKit2.Settings.props.default_monospace_font_size