### PR TITLE
Webkit2 fix for (shift)tab cycling through editable elements

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -38,6 +38,7 @@ void input_enter(Client *c)
      * disturbing the user */
     gtk_widget_grab_focus(GTK_WIDGET(c->webview));
     vb_modelabel_update(c, "-- INPUT --");
+    webkit_web_view_run_javascript(c->webview, "var vimb_input_mode_element = document.activeElement;", NULL, NULL, NULL);
 }
 
 /**
@@ -45,7 +46,7 @@ void input_enter(Client *c)
  */
 void input_leave(Client *c)
 {
-    webkit_web_view_run_javascript(c->webview, "document.activeElement.blur();", NULL, NULL, NULL);
+    webkit_web_view_run_javascript(c->webview, "vimb_input_mode_element.blur();", NULL, NULL, NULL);
     vb_modelabel_update(c, "");
 }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -215,7 +215,6 @@ extern struct Vimb vb;
  */
 void normal_enter(Client *c)
 {
-    webkit_web_view_run_javascript(c->webview, "document.activeElement.blur();", NULL, NULL, NULL);
     /* Make sure that when the browser area becomes visible, it will get mouse
      * and keyboard events */
     gtk_widget_grab_focus(GTK_WIDGET(c->webview));
@@ -322,6 +321,7 @@ void pass_enter(Client *c)
  */
 void pass_leave(Client *c)
 {
+    webkit_web_view_run_javascript(c->webview, "document.activeElement.blur();", NULL, NULL, NULL);
     vb_modelabel_update(c, "");
 }
 


### PR DESCRIPTION
This changes fix cycling focus through editable elements by pressing tab or shift+tab on the webkit2 branch.

### Steps to reproduce

 * Go to normal mode (disable pass through mode)
 * Focus an editable element, e.g. the "First name" input element on https://www.w3schools.com/html/html_forms.asp (vimb enters input mode)
 * Press tab to step one element further

**Expected behaviour**
 * The "Last name" element is focussed
 * vimb is in input mode

**Actual behaviour**
 * No element is focussed
 * vimb is in normal mode


**Note:** A workaround for this issue is to enter pass through mode by pressing CTRL+Z before focussing the first element.

### Analysis
Apparently, the issue is due to a race condition. When the tab key is pressed, webkit notifies vimb about the focus change (two events: blur first element, focus second element). On the vimb side, this leads to leaving input mode and entering normal mode and vice versa. When vimb leaves input mode and/or enters normal mode, the **currently** focussed element is blurred using js code. With webkit2 ```webkit_web_view_run_javascript``` executes asynchronously, so when the js code is executed, the currently active element was already changed by webkit, as webkit handled the tab key before. So the next input element, which was just focussed by webkit, is instantly blurred by the js code injected by vimb.

### Solution
My solution is pretty simple. Curious whether you guys like it. 

**First**, on entering input mode, I store the "currently focussed element", and on leaving input mode, I blur the element stored, not the one which is now currently focussed. To bypass all the pain of IPC and race conditions, I store the "currently focussed element" directly in js.

**Second**, I now handle blurring of elements only when entering and leaving input mode and leaving pass through mode, but not again on entering normal mode. This eliminates complications of doing it twice when entering normal mode.

**Pro**: Easy and straight forward.
**Cons**: Ugly global variable in js.

What do you think?

