### PR TITLE
Webkit2: ctrl+p and ctrl+n for ex history movement

### DIFF
--- a/src/ex.c
+++ b/src/ex.c
@@ -262,11 +262,13 @@ VbResult ex_keypress(Client *c, int key)
                 complete(c, -1);
                 break;
 
-            case KEY_UP:
+            case KEY_UP: /* fall through */
+            case CTRL('P'):
                 history(c, TRUE);
                 break;
 
-            case KEY_DOWN:
+            case KEY_DOWN: /* fall through */
+            case CTRL('N'):
                 history(c, FALSE);
                 break;
 


### PR DESCRIPTION
Vim supports ```CTRL+p``` and ```CTRL+n``` for ex command history movement (and so do bash and zsh). 

Find attached the patch to add it to vimb as well.