### PR TITLE
Allow shortcuts without parameters

### DIFF
--- a/src/shortcut.c
+++ b/src/shortcut.c
@@ -202,6 +202,8 @@ static const char *shortcut_lookup(Client *c, const char *string, const char **q
             *query = p + 1;
         }
         g_free(key);
+    } else {
+        uri = g_hash_table_lookup(c->shortcut.table, string);
     }
 
     if (!uri && c->shortcut.fallback


### PR DESCRIPTION
This change provides a simple way to allow calling shortcuts without parameters.

I see several positive effects:

### Navigate to your favourite pages via shortcuts
Without necessarily going to search there but check the news feed or what so ever.

### Compromise for #284 
You could now do:
```
shortcut-add w=https://en.wikipedia.org/wiki/Main_Page
shortcut-add ws=http://en.wikipedia.org/wiki/Special:Search?search=$0
```
So you would have to define two shortcuts, but basically it allows the workflow @aksr requested.

### Compromise for #181

Say you set a duckduckgo short via:

```
shortcut-add du=https://duckduckgo.com/?q=$0
```

You can now ```:open du some search string``` as usual. But you can also just ```:open du``` which will bring you to the duckduckgo front page featuring search suggestions. Several search engines I tested send you to the search front page if the url query was empty. So it's a way to rapidly access search suggestions without vimb implementing it :) Maybe it helps the workflow of @257

What do you think?