### PR TITLE
Fix for input box prompt color after error

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -506,7 +506,8 @@ static VbResult normal_increment_decrement(Client *c, const NormalCmdInfo *info)
 static VbResult normal_input_open(Client *c, const NormalCmdInfo *info)
 {
     if (strchr("ot", info->key)) {
-        vb_input_set_text(c, info->key == 't' ? ":tabopen " : ":open ");
+        vb_echo(c, MSG_NORMAL, FALSE,
+                ":%s ", info->key == 't' ? "tabopen" : "open");
     } else {
         vb_echo(c, MSG_NORMAL, FALSE,
                 ":%s %s", info->key == 'T' ? "tabopen" : "open", c->state.uri);


### PR DESCRIPTION
When an error message is displayed by the input box, the next ```:open``` and ```:tabopen``` commands entered using ```o``` and ```t``` keys are rendered using input error color, not input normal color.

## Steps to reproduce
- run a non existing command, e.g. ```:asdf```
- input box will print ```Unknown command: asdf``` using input error color
- type ```t``` or ```o``` to open an URL

## Expected behaviour
- input box prints using input normal color

## Actual behaviour
- input box prints using input error color