### PR TITLE
fixes src/vimb target to be phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ sandbox:
 runsandbox: sandbox
 	sandbox/usr/bin/vimb
 
-.PHONY: all vimb options clean install uninstall sandbox
+.PHONY: all options $(SRCDIR)/vimb install uninstall clean sandbox runsandbox


### PR DESCRIPTION
There is a problem with the new make infrastructure. Running ```make``` from the project root does not consider the dependencies of ```src/vimb```. So changes in source files do not lead to a rebuild.

This branch fixes this issue by defining ```src/vimb``` phony.

### Steps to reproduce
- run ```make``` from the project root, the ```vimb``` binary will build
- change a file, e.g. ```src/main.c```
- run ```make``` from the project root again

### Expected behaviour
- ```vimb``` binary will be rebuild

### Actual behaviour
- ```vimb``` binary is considered up to date and will not be rebuild