### PR TITLE
Make verbose option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ uninstall:
 clean: $(SRCDIR).subdir-clean
 
 sandbox:
-	@make $(MFLAGS) RUNPREFIX=$(CURDIR)/sandbox/usr PREFIX=/usr DESTDIR=./sandbox install
+	$(Q)$(MAKE) $(MFLAGS) RUNPREFIX=$(CURDIR)/sandbox/usr PREFIX=/usr DESTDIR=./sandbox install
 
 runsandbox: sandbox
 	sandbox/usr/bin/vimb
 
 %.subdir-all:
-	@$(MAKE) $(MFLAGS) -C $*
+	$(Q)$(MAKE) $(MFLAGS) -C $*
 
 %.subdir-clean:
-	@$(MAKE) $(MFLAGS) -C $* clean
+	$(Q)$(MAKE) $(MFLAGS) -C $* clean
 
 .PHONY: all options install uninstall clean sandbox runsandbox

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,9 @@
 VERSION = dev-3.0
 
+ifneq ($(V),1)
+Q := @
+endif
+
 PREFIX           ?= /usr/local
 BINPREFIX        := $(DESTDIR)$(PREFIX)/bin
 MANPREFIX        := $(DESTDIR)$(PREFIX)/share/man

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,31 +11,32 @@ clean: $(SUBDIRS:%=%.subdir-clean)
 	$(RM) vimb *.o scripts/scripts.h
 
 vimb: $(OBJ)
-	$(CC) $(LDFLAGS) $(OBJ) -o $@
+	$(Q)echo "${CC} $@"
+	$(Q)$(CC) $(LDFLAGS) $(OBJ) -o $@
 
 $(OBJ): config.h $(BASEDIR)/config.mk scripts/scripts.h
 
 -include $(OBJ:.o=.d)
 
 config.h:
-	@echo create $@ from config.def.h
-	@cp config.def.h $@
+	$(Q)echo create $@ from config.def.h
+	$(Q)cp config.def.h $@
 
 scripts/scripts.h: $(JSFILES)
-	$(RM) $@
-	@echo "create $@ from *.js"
-	@for file in $(JSFILES); do \
+	$(Q)$(RM) $@
+	$(Q)echo "create $@ from *.js"
+	$(Q)for file in $(JSFILES); do \
 		./scripts/js2h.sh $$file >> $@; \
 	done
 
 %.o: %.c
-	@echo "${CC} $@"
-	@$(CC) $(CFLAGS) -c -o $@ $<
+	$(Q)echo "${CC} $@"
+	$(Q)$(CC) $(CFLAGS) -c -o $@ $<
 
 %.subdir-all: config.h
-	@$(MAKE) $(MFLAGS) -C $*
+	$(Q)$(MAKE) $(MFLAGS) -C $*
 
 %.subdir-clean:
-	@$(MAKE) $(MFLAGS) -C $* clean
+	$(Q)$(MAKE) $(MFLAGS) -C $* clean
 
 .PHONY: all clean

--- a/src/webextension/Makefile
+++ b/src/webextension/Makefile
@@ -9,11 +9,11 @@ clean:
 	$(RM) $(EXTTARGET) *.lo
 
 $(EXTTARGET): $(OBJ)
-	@echo "$(CC) $@"
-	@$(CC) $(EXTLDFLAGS) ${OBJ} -o $@
+	$(Q)echo "$(CC) $@"
+	$(Q)$(CC) $(EXTLDFLAGS) ${OBJ} -o $@
 
 %.lo: %.c
-	@echo "${CC} $@"
-	@$(CC) $(EXTCFLAGS) -fPIC -c -o $@ $<
+	$(Q)echo "${CC} $@"
+	$(Q)$(CC) $(EXTCFLAGS) -fPIC -c -o $@ $<
 
 .PHONY: all clean


### PR DESCRIPTION
This patch adds a make option ```V``` to enable verbose builds, off by default.

Run ```make``` to get the pretty printed build as usual.
Run ```make V=1``` to get the full compiler command lines.