### PR TITLE
config.mk simplification

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -17,23 +17,23 @@ DOCDIR  = doc
 LIBS = gtk+-3.0 'webkit2gtk-4.0 >= 2.3.5'
 
 # setup general used CFLAGS
-CFLAGS   += -std=c99 -pipe -Wall
-#CPPFLAGS += -pedantic
-CPPFLAGS += -DVERSION=\"${VERSION}\" -DEXTENSIONDIR=\"${EXTENSIONDIR}\"
-CPPFLAGS += -DPROJECT=\"vimb\" -DPROJECT_UCFIRST=\"Vimb\"
-CPPFLAGS += -D_XOPEN_SOURCE=500
-CPPFLAGS += -DGSEAL_ENABLE
-CPPFLAGS += -DGTK_DISABLE_SINGLE_INCLUDES
-CPPFLAGS += -DGDK_DISABLE_DEPRECATED
+CFLAGS     += -std=c99 -pipe -Wall
+#CFLAGS     += -pedantic
+CFLAGS     += -DVERSION=\"${VERSION}\" -DEXTENSIONDIR=\"${EXTENSIONDIR}\"
+CFLAGS     += -DPROJECT=\"vimb\" -DPROJECT_UCFIRST=\"Vimb\"
+CFLAGS     += -D_XOPEN_SOURCE=500
+CFLAGS     += -DGSEAL_ENABLE
+CFLAGS     += -DGTK_DISABLE_SINGLE_INCLUDES
+CFLAGS     += -DGDK_DISABLE_DEPRECATED
 
 # flags used to build webextension
 EXTTARGET   = webext_main.so
 EXTCFLAGS   = ${CFLAGS} -fPIC $(shell pkg-config --cflags webkit2gtk-4.0)
-EXTCFLAGS  += $(CPPFLAGS)
 EXTLDFLAGS  = $(shell pkg-config --libs webkit2gtk-4.0) -shared
 
 # flags used for the main application
 CFLAGS     += $(shell pkg-config --cflags $(LIBS))
-CFLAGS     += ${CPPFLAGS}
 LDFLAGS    += $(shell pkg-config --libs $(LIBS))
+
+# flags for make
 MFLAGS      = --no-print-directory


### PR DESCRIPTION
This patch removes the distinction between ```CFLAGS``` and ```CXXFLAGS``` from ```config.mk```. I think it is simpler like this. Hope I do not miss anything.