### PR TITLE
Fix incsearch history handling

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -43,7 +43,7 @@ enum {
 };
 #endif
 
-gboolean command_search(Client *c, const Arg *arg);
+gboolean command_search(Client *c, const Arg *arg, bool commit);
 gboolean command_yank(Client *c, const Arg *arg, char buf);
 gboolean command_save(Client *c, const Arg *arg);
 #ifdef FEATURE_QUEUE

--- a/src/ex.c
+++ b/src/ex.c
@@ -402,8 +402,7 @@ void ex_input_changed(Client *c, const char *text)
         case '/': /* fall through */
         case '?':
             if (c->config.incsearch) {
-                command_search(c, &((Arg){0, NULL})); /* stop last search */
-                command_search(c, &((Arg){*text == '/' ? 1 : -1, (char*)text + 1}));
+                command_search(c, &((Arg){*text == '/' ? 1 : -1, (char*)text + 1}), FALSE);
             }
             break;
     }
@@ -511,10 +510,7 @@ static void input_activate(Client *c)
         case '?':
             vb_enter(c, 'n');
 
-            /* start search, if incsearch, it's done while typing */
-            if (!c->config.incsearch) {
-                command_search(c, &((Arg){count, cmd}));
-            }
+            command_search(c, &((Arg){count, strlen(cmd) ? cmd : NULL}), TRUE);
             break;
 
         case ';': /* fall through */

--- a/src/main.c
+++ b/src/main.c
@@ -1202,7 +1202,7 @@ static void on_webview_load_changed(WebKitWebView *webview,
             marks_clear(c);
 
             /* Unset possible last search. */
-            command_search(c, &((Arg){0}));
+            command_search(c, &(Arg){0, NULL}, FALSE);
 
             break;
 

--- a/src/main.h
+++ b/src/main.h
@@ -173,9 +173,9 @@ struct State {
     WebKitHitTestResult *hit_test_result;
 
     struct {
-        gboolean    active;         /* indicate if there is a acitve search */
+        gboolean    active;         /* indicate if there is a active search */
         short       direction;      /* last direction 1 forward, -1 backward */
-        int         matches;        /* number of matches search results */
+        int         matches;        /* number of matching search results */
     } search;
 };
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -227,7 +227,7 @@ void normal_enter(Client *c)
  */
 void normal_leave(Client *c)
 {
-    command_search(c, &((Arg){0}));
+    command_search(c, &((Arg){0, NULL}), FALSE);
 }
 
 /**
@@ -344,7 +344,7 @@ static VbResult normal_clear_input(Client *c, const NormalCmdInfo *info)
     vb_echo(c, MSG_NORMAL, FALSE, "");
 
     /* Unset search highlightning. */
-    command_search(c, &((Arg){0}));
+    command_search(c, &((Arg){0, NULL}), FALSE);
 
     return RESULT_COMPLETE;
 }
@@ -728,7 +728,7 @@ static VbResult normal_search(Client *c, const NormalCmdInfo *info)
 {
     int count = (info->count > 0) ? info->count : 1;
 
-    command_search(c, &((Arg){info->key == 'n' ? count : -count}));
+    command_search(c, &((Arg){info->key == 'n' ? count : -count, NULL}), FALSE);
 
     return RESULT_COMPLETE;
 }
@@ -747,10 +747,7 @@ static VbResult normal_search_selection(Client *c, const NormalCmdInfo *info)
     }
     count = (info->count > 0) ? info->count : 1;
 
-    /* stopp possible existing search and the search highlights before
-     * starting the new search query */
-    command_search(c, &((Arg){0}));
-    command_search(c, &((Arg){info->key == '*' ? count : -count, query}));
+    command_search(c, &((Arg){info->key == '*' ? count : -count, query}), TRUE);
     g_free(query);
 
     return RESULT_COMPLETE;


### PR DESCRIPTION
This patch fixes #372 ```incsearch``` history handling by refactoring parts of ```command_search()```. ```command_search()``` does now explicitely know when a new search string is *commited* by hitting ```<enter>``` or searching for the current selection. Intermediate search strings when using ```incsearch``` are not considered *commited*.

As a side effect search using the ```"/``` register (type ```/<enter>```) was fixed.