### PR TITLE
Re-implement hints into webkit2 (#349)

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -130,7 +130,10 @@ gboolean command_yank(Client *c, const Arg *arg, char buf)
     g_assert(c);
     g_assert(arg);
     g_assert(c->webview);
-    g_assert(arg->i == COMMAND_YANK_URI || arg->i == COMMAND_YANK_SELECTION);
+    g_assert(
+        arg->i == COMMAND_YANK_URI ||
+        arg->i == COMMAND_YANK_SELECTION ||
+        arg->i == COMMAND_YANK_ARG);
 
     if (arg->i == COMMAND_YANK_URI) {
         if ((uri = webkit_web_view_get_uri(c->webview))) {
@@ -141,6 +144,9 @@ gboolean command_yank(Client *c, const Arg *arg, char buf)
         webkit_web_view_execute_editing_command(c->webview, WEBKIT_EDITING_COMMAND_COPY);
         /* read back copy from clipboard */
         yanked = gtk_clipboard_wait_for_text(gtk_clipboard_get(GDK_SELECTION_PRIMARY));
+    } else {
+        /* use current arg.s as new clipboard content */
+        yanked = g_strdup(arg->s);
     }
 
     if(!yanked) {

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -51,6 +51,8 @@
 #define SETTING_GUI_FONT_EMPH                 "bold 10pt monospace"
 #define SETTING_HOME_PAGE                     "about:blank"
 
+#define MAXIMUM_HINTS              500
+
 /* CSS style use on creating hints. This might also be averrules by css out of
  * $XDG_CONFIG_HOME/vimb/style.css file. */
 #define HINT_CSS "#_hintContainer{\

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -50,3 +50,35 @@
 #define SETTING_GUI_FONT_NORMAL               "10pt monospace"
 #define SETTING_GUI_FONT_EMPH                 "bold 10pt monospace"
 #define SETTING_HOME_PAGE                     "about:blank"
+
+/* CSS style use on creating hints. This might also be averrules by css out of
+ * $XDG_CONFIG_HOME/vimb/style.css file. */
+#define HINT_CSS "#_hintContainer{\
+position:static\
+}\
+._hintLabel{\
+-webkit-transform:translate(-4px,-4px);\
+position:absolute;\
+z-index:100000;\
+font:bold .8em monospace;\
+color:#000;\
+background-color:#fff;\
+margin:0;\
+padding:0px 1px;\
+border:1px solid #444;\
+opacity:0.7\
+}\
+._hintElem{\
+background-color:#ff0 !important;\
+color:#000 !important;\
+transition:all 0 !important;\
+transition-delay:all 0 !important\
+}\
+._hintElem._hintFocus{\
+background-color:#8f0 !important\
+}\
+._hintLabel._hintFocus{\
+z-index:100001;\
+opacity:1\
+}"
+

--- a/src/ex.c
+++ b/src/ex.c
@@ -241,7 +241,12 @@ VbResult ex_keypress(Client *c, int key)
     VbResult res;
     const char *text;
 
-    /* TODO delegate call to hint mode if this is active */
+    /* delegate call to hint mode if this is active */
+    if (c->mode->flags & FLAG_HINTING
+        && RESULT_COMPLETE == hints_keypress(c, key)) {
+
+        return RESULT_COMPLETE;
+    }
 
     /* process the register */
     if (info.phase == PHASE_REG) {

--- a/src/ex.c
+++ b/src/ex.c
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "ex.h"
 #include "handler.h"
+#include "hints.h"
 #include "history.h"
 #include "main.h"
 #include "map.h"
@@ -225,9 +226,7 @@ void ex_enter(Client *c)
 void ex_leave(Client *c)
 {
     completion_clean(c);
-#if 0
-    hints_clear();
-#endif
+    hints_clear(c);
 }
 
 /**
@@ -397,7 +396,7 @@ void ex_input_changed(Client *c, const char *text)
     switch (*text) {
         case ';': /* fall through - the modes are handled by hints_create */
         case 'g':
-            /* TODO create hints */
+            hints_create(c, text);
             break;
         case '/': /* fall through */
         case '?':

--- a/src/hints.c
+++ b/src/hints.c
@@ -1,0 +1,379 @@
+/**
+ * vimb - a webkit based vim like browser.
+ *
+ * Copyright (C) 2012-2017 Daniel Carl
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#include "config.h"
+#include <string.h>
+#include <JavaScriptCore/JavaScript.h>
+#include <gdk/gdkkeysyms.h>
+#include <gdk/gdkkeysyms-compat.h>
+#include "hints.h"
+#include "main.h"
+#include "ascii.h"
+#include "command.h"
+#include "hints.js.h"
+#include "input.h"
+#include "map.h"
+#include "ext-proxy.h"
+
+static struct {
+    JSObjectRef    obj;       /* the js object */
+    char           mode;      /* mode identifying char - that last char of the hint prompt */
+    int            promptlen; /* length of the hint prompt chars 2 or 3 */
+    gboolean       gmode;     /* indicate if the hints 'g' mode is used */
+    JSContextRef   ctx;
+    /* holds the setting if JavaScript can open windows automatically that we
+     * have to change to open windows via hinting */
+    gboolean       allow_open_win;
+    guint          timeout_id;
+} hints;
+
+extern struct Vimb vb;
+
+static gboolean call_hints_function(Client *c, const char *func, int count, JSValueRef params[]);
+static void fire_timeout(Client *c, gboolean on);
+static gboolean fire_cb(gpointer data);
+
+
+VbResult hints_keypress(Client *c, int key)
+{
+    JSValueRef arguments[1];
+
+    if (key == KEY_CR) {
+        hints_fire(c);
+
+        return RESULT_COMPLETE;
+    } else if (key == CTRL('H')) {
+        fire_timeout(c, false);
+        arguments[0] = JSValueMakeNull(hints.ctx);
+        if (call_hints_function(c, "update", 1, arguments)) {
+            return RESULT_COMPLETE;
+        }
+    } else if (key == KEY_TAB) {
+        fire_timeout(c, false);
+        hints_focus_next(c, false);
+
+        return RESULT_COMPLETE;
+    } else if (key == KEY_SHIFT_TAB) {
+        fire_timeout(c, false);
+        hints_focus_next(c, true);
+
+        return RESULT_COMPLETE;
+    } else {
+        fire_timeout(c, true);
+        /* try to handle the key by the javascript */
+        /* arguments[0] = js_string_to_ref(hints.ctx, (char[]){key, '\0'}); */
+        /* if (call_hints_function(c, "update", 1, arguments)) {            */
+        /*     return RESULT_COMPLETE;                                      */
+        /* }                                                                */
+    }
+
+    fire_timeout(c, false);
+    return RESULT_ERROR;
+}
+
+void hints_clear(Client *c)
+{
+    if (c->mode->flags & FLAG_HINTING) {
+        c->mode->flags &= ~FLAG_HINTING;
+        vb_input_set_text(c, "");
+
+        call_hints_function(c, "clear", 0, NULL);
+
+        g_signal_emit_by_name(c->webview, "hovering-over-link", NULL, NULL);
+
+        /* if open window was not allowed for JavaScript, restore this */
+        /* if (!hints.allow_open_win) {                                                                                  */
+        /*     WebKitWebSettings *setting = webkit_web_view_get_settings(c->webview);                                    */
+        /*     g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", hints.allow_open_win, NULL); */
+        /* }                                                                                                             */
+    }
+}
+
+void hints_create(Client *c, const char *input)
+{
+    char *jscode;
+
+    /* check if the input contains a valid hinting prompt */
+    if (!hints_parse_prompt(input, &hints.mode, &hints.gmode)) {
+        /* if input is not valid, clear possible previous hint mode */
+        if (c->mode->flags & FLAG_HINTING) {
+            vb_enter(c, 'n');
+        }
+        return;
+    }
+
+    if (!(c->mode->flags & FLAG_HINTING)) {
+        c->mode->flags |= FLAG_HINTING;
+
+        /* WebKitWebSettings *setting = webkit_web_view_get_settings(c->webview); */
+
+        /* before we enable JavaScript to open new windows, we save the actual
+         * value to be able restore it after hints where fired */
+        /* g_object_get(G_OBJECT(setting), "javascript-can-open-windows-automatically", &(hints.allow_open_win), NULL); */
+
+        /* if window open is already allowed there's no need to allow it again */
+        /* if (!hints.allow_open_win) {                                                                  */
+        /*     g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", true, NULL); */
+        /* }                                                                                             */
+
+        hints.promptlen = hints.gmode ? 3 : 2;
+
+        jscode = g_strdup_printf("hints.init('%s', %s, %d, '%s', %s, %s);",
+            (char[]){hints.mode, '\0'},
+            hints.gmode ? "true" : "false",
+            MAXIMUM_HINTS,
+            GET_CHAR(c, "hintkeys"),
+            GET_BOOL(c, "hint-follow-last") ? "true" : "false",      
+            GET_BOOL(c, "hint-number-same-length") ? "true" : "false"
+        );
+
+        ext_proxy_eval_script(c, jscode, NULL);
+        g_free(jscode);
+
+        /* if hinting is started there won't be any additional filter given and
+         * we can go out of this function */
+        return;
+    }
+
+    /* JSValueRef arguments[] = {js_string_to_ref(hints.ctx, *(input + hints.promptlen) ? input + hints.promptlen : "")}; */
+    /* call_hints_function(c, "filter", 1, arguments);                                                                    */
+}
+
+void hints_focus_next(Client *c, const gboolean back)
+{
+    JSValueRef arguments[] = {
+        JSValueMakeNumber(hints.ctx, back)
+    };
+    call_hints_function(c, "focus", 1, arguments);
+}
+
+void hints_fire(Client *c)
+{
+    call_hints_function(c, "fire", 0, NULL);
+}
+
+void hints_follow_link(Client *c, const gboolean back, int count)
+{
+    /* char *json = g_strdup_printf(                            */
+    /*     "[%s]",                                              */
+    /*     back ? vb.config.prevpattern : vb.config.nextpattern */
+    /* );                                                       */
+
+    /* JSValueRef arguments[] = {                               */
+    /*     js_string_to_ref(hints.ctx, back ? "prev" : "next"), */
+    /*     js_object_to_ref(hints.ctx, json),                   */
+    /*     JSValueMakeNumber(hints.ctx, count)                  */
+    /* };                                                       */
+    /* g_free(json);                                            */
+
+    /* call_hints_function(c, "followLink", 3, arguments);         */
+}
+
+void hints_increment_uri(Client *c, int count)
+{
+    JSValueRef arguments[] = {
+        JSValueMakeNumber(hints.ctx, count)
+    };
+
+    call_hints_function(c, "incrementUri", 1, arguments);
+}
+
+/**
+ * Checks if the given hint prompt belong to a known and valid hints mode and
+ * parses the mode and is_gmode into given pointers.
+ *
+ * The given prompt sting may also contain additional chars after the prompt.
+ *
+ * @prompt:   String to be parsed as prompt. The Prompt can be followed by
+ *            additional characters.
+ * @mode:     Pointer to char that will be filled with mode char if prompt was
+ *            valid and given pointer is not NULL.
+ * @is_gmode: Pointer to gboolean to be filled with the flag to indicate gmode
+ *            hinting.
+ */
+gboolean hints_parse_prompt(const char *prompt, char *mode, gboolean *is_gmode)
+{
+    gboolean res;
+    char pmode = '\0';
+#ifdef FEATURE_QUEUE
+    static char *modes   = "eiIoOpPstTxyY";
+    static char *g_modes = "IpPstyY";
+#else
+    static char *modes   = "eiIoOstTxyY";
+    static char *g_modes = "IstyY";
+#endif
+
+    if (!prompt) {
+        return false;
+    }
+
+    /* get the mode identifying char from prompt */
+    if (*prompt == ';') {
+        pmode = prompt[1];
+    } else if (*prompt == 'g' && strlen(prompt) >= 3) {
+        /* get mode for g;X hint modes */
+        pmode = prompt[2];
+    }
+
+    /* no mode found in prompt */
+    if (!pmode) {
+        return false;
+    }
+
+    res = *prompt == 'g'
+        ? strchr(g_modes, pmode) != NULL
+        : strchr(modes, pmode) != NULL;
+
+    /* fill pointer only if the prompt was valid */
+    if (res) {
+        if (mode != NULL) {
+            *mode = pmode;
+        }
+        if (is_gmode != NULL) {
+            *is_gmode = *prompt == 'g';
+        }
+    }
+
+    return res;
+}
+
+static gboolean call_hints_function(Client *c, const char *func, int count, JSValueRef params[])
+{
+    /* char *value = js_object_call_function(hints.ctx, hints.obj, func, count, params); */
+    char *value = "";
+    return true;
+
+    g_return_val_if_fail(value != NULL, false);
+
+    if (!strncmp(value, "ERROR:", 6)) {
+        g_free(value);
+        return false;
+    }
+
+    if (!strncmp(value, "OVER:", 5)) {
+        g_signal_emit_by_name(
+            c->webview, "hovering-over-link", NULL, *(value + 5) == '\0' ? NULL : (value + 5)
+        );
+        g_free(value);
+
+        return true;
+    }
+
+    /* following return values mark fired hints */
+    if (!strncmp(value, "DONE:", 5)) {
+        fire_timeout(c, false);
+        /* Change to normal mode only if we are currently in command mode and
+         * we are not in g-mode hinting. This is required to not switch to
+         * normal mode when the hinting triggered a click that set focus on
+         * editable element that lead vimb to switch to input mode. */
+        if (!hints.gmode && c->mode->id == 'c') {
+            vb_enter(c, 'n');
+        }
+    } else if (!strncmp(value, "INSERT:", 7)) {
+        fire_timeout(c, false);
+        vb_enter(c, 'i');
+        if (hints.mode == 'e') {
+            input_open_editor(c);
+        }
+    } else if (!strncmp(value, "DATA:", 5)) {
+        fire_timeout(c, false);
+        /* switch first to normal mode - else we would clear the inputbox
+         * on switching mode also if we want to show yanked data */
+        if (!hints.gmode) {
+            vb_enter(c, 'n');
+        }
+
+        char *v = (value + 5);
+        Arg a   = {0};
+        /* put the hinted value into register "; */
+        vb_register_add(c, ';', v);
+        switch (hints.mode) {
+            /* used if images should be opened */
+            case 'i':
+            case 'I':
+                a.s = v;
+                a.i = (hints.mode == 'I') ? TARGET_NEW : TARGET_CURRENT;
+                vb_load_uri(c, &a);
+                break;
+
+            case 'O':
+            case 'T':
+                vb_echo(c, MSG_NORMAL, false, "%s %s", (hints.mode == 'T') ? ":tabopen" : ":open", v);
+                if (!hints.gmode) {
+                    vb_enter(c, 'c');
+                }
+                break;
+
+            case 's':
+                a.s = v;
+                a.i = COMMAND_SAVE_URI;
+                command_save(c, &a);
+                break;
+
+            case 'x':
+                map_handle_string(c, GET_CHAR(c, "x-hint-command"), true);
+                break;
+
+            case 'y':
+            case 'Y':
+                a.i = COMMAND_YANK_ARG;
+                a.s = v;
+                command_yank(c, &a, c->state.current_register);
+                break;
+
+#ifdef FEATURE_QUEUE
+            case 'p':
+            case 'P':
+                a.s = v;
+                a.i = (hints.mode == 'P') ? COMMAND_QUEUE_UNSHIFT : COMMAND_QUEUE_PUSH;
+                command_queue(c, &a);
+                break;
+#endif
+        }
+    }
+    g_free(value);
+    return true;
+}
+
+static void fire_timeout(Client *c, gboolean on)
+{
+    int millis;
+    /* remove possible timeout function */
+    if (hints.timeout_id) {
+        g_source_remove(hints.timeout_id);
+        hints.timeout_id = 0;
+    }
+
+    if (on) {
+        millis = GET_INT(c, "hint-timeout");
+        if (millis) {
+            hints.timeout_id = g_timeout_add(millis, (GSourceFunc)fire_cb, c);
+        }
+    }
+}
+
+static gboolean fire_cb(gpointer data)
+{
+    hints_fire(data);
+
+    /* remove timeout id for the timeout that is removed by return value of
+     * false automatic */
+    hints.timeout_id = 0;
+    return false;
+}

--- a/src/hints.h
+++ b/src/hints.h
@@ -23,7 +23,7 @@
 #include "main.h"
 
 VbResult hints_keypress(Client *c, int key);
-void hints_create(Client *c, char *input);
+void hints_create(Client *c, const char *input);
 void hints_fire(Client *c);
 void hints_follow_link(Client *c, gboolean back, int count);
 void hints_increment_uri(Client *c, int count);

--- a/src/hints.h
+++ b/src/hints.h
@@ -1,0 +1,34 @@
+/**
+ * vimb - a webkit based vim like browser.
+ *
+ * Copyright (C) 2012-2016 Daniel Carl
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+#ifndef _HINTS_H
+#define _HINTS_H
+
+#include "main.h"
+
+VbResult hints_keypress(Client *c, int key);
+void hints_create(Client *c, const char *input);
+void hints_fire(Client *c);
+void hints_follow_link(Client *c, gboolean back, int count);
+void hints_increment_uri(Client *c, int count);
+gboolean hints_parse_prompt(const char *prompt, char *mode, gboolean *is_gmode);
+void hints_clear(Client *c);
+void hints_focus_next(Client *c, const gboolean back);
+
+#endif /* end of include guard: _HINTS_H */

--- a/src/hints.h
+++ b/src/hints.h
@@ -23,7 +23,7 @@
 #include "main.h"
 
 VbResult hints_keypress(Client *c, int key);
-void hints_create(Client *c, const char *input);
+void hints_create(Client *c, char *input);
 void hints_fire(Client *c);
 void hints_follow_link(Client *c, gboolean back, int count);
 void hints_increment_uri(Client *c, int count);

--- a/src/main.c
+++ b/src/main.c
@@ -1625,6 +1625,7 @@ static WebKitWebView *webview_new(Client *c, WebKitWebView *webview)
 {
     WebKitWebView *new;
     WebKitUserContentManager *ucm;
+    WebKitUserScript *script;
 
     /* create a new webview */
     if (webview) {
@@ -1651,6 +1652,13 @@ static WebKitWebView *webview_new(Client *c, WebKitWebView *webview)
     );
 
     g_signal_connect(webkit_web_context_get_default(), "download-started", G_CALLBACK(on_webctx_download_started), c);
+
+    /* Inject the global hints script. */
+    script = webkit_user_script_new(HINTS,
+            WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
+            WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END, NULL, NULL);
+    webkit_user_content_manager_add_script(ucm, script);
+    webkit_user_script_unref(script);
 
     /* Setup script message handlers. */
     webkit_user_content_manager_register_script_message_handler(ucm, "focus");

--- a/src/normal.c
+++ b/src/normal.c
@@ -408,9 +408,7 @@ static VbResult normal_ex(Client *c, const NormalCmdInfo *info)
     if (info->key == 'F') {
         vb_enter_prompt(c, 'c', ";t", TRUE);
     } else if (info->key == 'f') {
-        g_print("firing!");
-        ext_proxy_eval_script(c, "testHint();", NULL);
-        /* vb_enter_prompt(c, 'c', ";o", TRUE); */
+        vb_enter_prompt(c, 'c', ";o", TRUE);
     } else {
         char prompt[2] = {info->key, '\0'};
         vb_enter_prompt(c, 'c', prompt, TRUE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -408,7 +408,9 @@ static VbResult normal_ex(Client *c, const NormalCmdInfo *info)
     if (info->key == 'F') {
         vb_enter_prompt(c, 'c', ";t", TRUE);
     } else if (info->key == 'f') {
-        vb_enter_prompt(c, 'c', ";o", TRUE);
+        g_print("firing!");
+        ext_proxy_eval_script(c, "testHint();", NULL);
+        /* vb_enter_prompt(c, 'c', ";o", TRUE); */
     } else {
         char prompt[2] = {info->key, '\0'};
         vb_enter_prompt(c, 'c', prompt, TRUE);

--- a/src/normal.c
+++ b/src/normal.c
@@ -621,7 +621,7 @@ static VbResult normal_pass(Client *c, const NormalCmdInfo *info)
 
 static VbResult normal_prevnext(Client *c, const NormalCmdInfo *info)
 {
-#if 0 /* TODO need hinting to be available */
+#if 0 /* TODO implement outside of hints.js */
     int count = info->count ? info->count : 1;
     if (info->key2 == ']') {
         hints_follow_link(FALSE, count);

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -541,5 +541,5 @@ var hints = Object.freeze((function(){
 
 function testHint() {
     console.log("harmless testing!");
-    /* hints.init('t', false, 500, '', false, false); */
+    hints.init('t', false, 500, '0123456789', false, false);
 }

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -1,0 +1,545 @@
+var hints = Object.freeze((function(){
+    'use strict';
+
+    var hints      = [],               /* holds all hint data (hinted element, label, number) in view port */
+        docs       = [],               /* hold the affected document with the start and end index of the hints */
+        validHints = [],               /* holds the valid hinted elements matching the filter condition */
+        activeHint,                    /* holds the active hint object */
+        filterText = "",               /* holds the typed filter text */
+        filterNum  = 0,                /* holds the numeric filter */
+        /* TODO remove these classes and use the 'vimbhint' attribute for */
+        /* styling the hints and labels - but this might break user */
+        /* stylesheets that use the classes for styling */
+        cId      = "_hintContainer",   /* id of the container holding the hint labels */
+        lClass   = "_hintLabel",       /* class used on the hint labels with the hint numbers */
+        hClass   = "_hintElem",        /* marks hinted elements */
+        fClass   = "_hintFocus",       /* marks focused element and focussed hint */
+        config;
+    /* the hint class used to maintain hinted element and labels */
+    function Hint() {
+        /* hide hint label and remove coloring from hinted element */
+        this.hide = function() {
+            /* remove hint labels from no more visible hints */
+            this.label.style.display = "none";
+            this.e.classList.remove(fClass);
+            this.e.classList.remove(hClass);
+        };
+
+        /* show the hint element colored with the hint label */
+        this.show = function() {
+            this.label.style.display = "";
+            this.e.classList.add(hClass);
+
+            /* create the label with the hint number */
+            var text = [];
+            if (this.e instanceof HTMLInputElement) {
+                var type = this.e.type;
+                if (type === "checkbox") {
+                    text.push(this.e.checked ? "☑" : "☐");
+                } else if (type === "radio") {
+                    text.push(this.e.checked ? "⊙" : "○");
+                }
+            }
+            if (this.showText && this.text) {
+                text.push(this.text.substr(0, 20));
+            }
+            /* use \x20 instead of ' ' to keep this space during js2h.sh processing */
+            this.label.innerText = this.num + (text.length ? ":\x20" + text.join("\x20") : "");
+        };
+    }
+
+    function clear() {
+        var i, j, doc, e;
+        for (i = 0; i < docs.length; i++) {
+            doc = docs[i];
+            /* find all hinted elements vimbhint 'hint' */
+            var res = xpath(doc.doc, "//*[contains(@vimbhint, 'hint')]");
+            for (j = 0; j < res.snapshotLength; j++) {
+                e = res.snapshotItem(j);
+                e.removeAttribute("vimbhint");
+                e.classList.remove(fClass);
+                e.classList.remove(hClass);
+            }
+            doc.div.parentNode.removeChild(doc.div);
+        }
+        docs       = [];
+        hints      = [];
+        validHints = [];
+        filterText = "";
+        filterNum  = 0;
+    }
+
+    function create() {
+        var count = 0;
+
+        function helper(win, offsets) {
+            /* document may be undefined for frames out of the same origin */
+            /* policy and will break the whole code - so we check this before */
+            if (typeof win.document == "undefined") {
+                return;
+            }
+
+            offsets        = offsets || {left: 0, right: 0, top: 0, bottom: 0};
+            offsets.right  = win.innerWidth  - offsets.right;
+            offsets.bottom = win.innerHeight - offsets.bottom;
+
+            /* checks if given elemente is in viewport and visible */
+            function isVisible(e) {
+                if (typeof e == "undefined") {
+                    return false;
+                }
+                var rect = e.getBoundingClientRect();
+                if (!rect ||
+                    rect.top >= offsets.bottom || rect.bottom <= offsets.top ||
+                    rect.left >= offsets.right || rect.right <= offsets.left
+                ) {
+                    return false;
+                }
+
+                if ((!rect.width || !rect.height) && (e.textContent || !e.name)) {
+                    var arr   = Array.prototype.slice.call(e.childNodes);
+                    var check = function(e) {
+                        return e instanceof Element
+                            && e.style.float != "none"
+                            && isVisible(e);
+                    };
+                    if (!arr.some(check)) {
+                        return false;
+                    }
+                }
+
+                var s = win.getComputedStyle(e, null);
+                return s.display !== "none" && s.visibility == "visible";
+            }
+
+            var doc       = win.document,
+                res       = xpath(doc, config.xpath),
+                /* generate basic hint element which will be cloned and updated later */
+                labelTmpl = doc.createElement("span"),
+                e, i;
+
+            labelTmpl.className = lClass;
+            labelTmpl.setAttribute("vimbhint", "label");
+
+            var containerOffsets = getOffsets(doc),
+                offsetX = containerOffsets[0],
+                offsetY = containerOffsets[1],
+                fragment = doc.createDocumentFragment(),
+                rect, label, text, showText, start = hints.length;
+
+            /* collect all visible elements in hints array */
+            for (i = 0; i < res.snapshotLength; i++) {
+                e = res.snapshotItem(i);
+                if (!isVisible(e)) {
+                    continue;
+                }
+
+                count++;
+
+                /* create the hint label with number */
+                rect  = e.getClientRects()[0];
+                label = labelTmpl.cloneNode(false);
+                label.setAttribute(
+                    "style", [
+                        "display:none;",
+                        "left:", Math.max((rect.left + offsetX), offsetX), "px;",
+                        "top:", Math.max((rect.top + offsetY), offsetY), "px;"
+                    ].join("")
+                );
+
+                /* if hinted element is an image - show title or alt of the image in hint label */
+                /* this allows to see how to filter for the image */
+                text = "";
+                showText = false;
+                if (e instanceof HTMLImageElement) {
+                    text     = e.title || e.alt;
+                    showText = true;
+                } else if (e.firstElementChild instanceof HTMLImageElement && /^\s*$/.test(e.textContent)) {
+                    text     = e.firstElementChild.title || e.firstElementChild.alt;
+                    showText = true;
+                } else if (e instanceof HTMLInputElement) {
+                    var type = e.type;
+                    if (type === "image") {
+                        text = e.alt || "";
+                    } else if (e.value && type !== "password") {
+                        text     = e.value;
+                        showText = (type === "radio" || type === "checkbox");
+                    }
+                } else if (e instanceof HTMLSelectElement) {
+                    if (e.selectedIndex >= 0) {
+                        text = e.item(e.selectedIndex).text;
+                    }
+                } else {
+                    text = e.textContent;
+                }
+                /* add the hint class to the hinted element */
+                fragment.appendChild(label);
+                e.setAttribute("vimbhint", "hint");
+
+                hints.push({
+                    e:         e,
+                    label:     label,
+                    text:      text,
+                    showText:  showText,
+                    __proto__: new Hint
+                });
+
+                if (count >= config.maxHints) {
+                    break;
+                }
+            }
+
+            /* append the fragment to the document */
+            var hDiv = doc.createElement("div");
+            hDiv.id  = cId;
+            hDiv.setAttribute("vimbhint", "container");
+            hDiv.appendChild(fragment);
+            if (doc.body) {
+                doc.body.appendChild(hDiv);
+            }
+            /* create the default style sheet */
+            createStyle(doc);
+
+            docs.push({
+                doc:   doc,
+                start: start,
+                end:   hints.length - 1,
+                div:   hDiv
+            });
+
+            /* recurse into any iframe or frame element */
+            for (i = 0; i < win.frames.length; i++) {
+                var rect,
+                    f = win.frames[i],
+                    e = f.frameElement;
+
+                if (isVisible(e)) {
+                    rect = e.getBoundingClientRect();
+                    helper(f, {
+                        left:   Math.max(offsets.left - rect.left, 0),
+                        right:  Math.max(rect.right   - offsets.right, 0),
+                        top:    Math.max(offsets.top  - rect.top, 0),
+                        bottom: Math.max(rect.bottom  - offsets.bottom, 0)
+                    });
+                }
+            }
+        }
+
+        helper(window);
+    }
+
+    function show(fireLast) {
+        var i, hint, newIdx,
+            n       = 1,
+            matcher = getMatcher(filterText),
+            str     = getHintString(filterNum);
+
+        if (config.hintNumSameLength) {
+            /* get number of hints to be shown */
+            var hintCount = 0;
+            for (i = 0; i < hints.length; i++) {
+                if (matcher(hints[i].text)) {
+                    hintCount++;
+                }
+            }
+            /* increase starting point of hint numbers until there are */
+            /* enough available numbers */
+            var len = config.hintKeys.length;
+            while (n * (len - 1) < hintCount) {
+                n *= len;
+            }
+        }
+
+        /* clear the array of valid hints */
+        validHints = [];
+        for (i = 0; i < hints.length; i++) {
+            hint = hints[i];
+            /* hide hints not matching the filter text */
+            if (!matcher(hint.text)) {
+                hint.hide();
+            } else {
+                /* assign the new hint number/letters as label to the hint */
+                hint.num = getHintString(n++);
+                /* check for number filter */
+                if (!filterNum || 0 === hint.num.indexOf(str)) {
+                    hint.show();
+                    validHints.push(hint);
+                } else {
+                    hint.hide();
+                }
+            }
+        }
+        if (fireLast && config.followLast && validHints.length <= 1) {
+            focusHint(0);
+            return fire();
+        }
+
+        /* if the previous active hint isn't valid set focus to first */
+        if (!activeHint || validHints.indexOf(activeHint) < 0) {
+            return focusHint(0);
+        }
+    }
+
+    /* Returns a validator method to check if the hint elements text matches */
+    /* the given filter text. */
+    function getMatcher(text) {
+        var tokens = text.toLowerCase().split(/\s+/);
+        return function (itemText) {
+            itemText = itemText.toLowerCase();
+            return tokens.every(function (token) {
+                return 0 <= itemText.indexOf(token);
+            });
+        };
+    }
+
+    /* Retrun the hint string for a given number based on configured hintkeys */
+    function getHintString(n) {
+        var res = [],
+            len = config.hintKeys.length;
+        do {
+            res.push(config.hintKeys[n % len]);
+            n = Math.floor(n / len);
+        } while (n > 0);
+
+        return res.reverse().join("");
+    }
+
+    function getOffsets(doc) {
+        var body  = doc.body || doc.documentElement,
+            style = body.style,
+            rect;
+
+        if (style && /^(absolute|fixed|relative)$/.test(style.position)) {
+            rect = body.getClientRects()[0];
+            return [-rect.left, -rect.top];
+        }
+        return [doc.defaultView.scrollX, doc.defaultView.scrollY];
+    }
+
+    function createStyle(doc) {
+        if (doc.hasStyle) {
+            return;
+        }
+        var e = doc.createElement("style");
+        /* HINT_CSS is replaces by the contents of the HINT_CSS constant from config.h */
+        e.innerHTML = "HINT_CSS";
+        doc.head.appendChild(e);
+        /* prevent us from adding the style multiple times */
+        doc.hasStyle = true;
+    }
+
+    function focus(back) {
+        var idx = validHints.indexOf(activeHint);
+        /* previous active hint not found */
+        if (idx < 0) {
+            idx = 0;
+        }
+
+        if (back) {
+            if (--idx < 0) {
+                idx = validHints.length - 1;
+            }
+        } else {
+            if (++idx >= validHints.length) {
+                idx = 0;
+            }
+        }
+        return focusHint(idx);
+    }
+
+    function fire() {
+        if (!activeHint) {
+            return "ERROR:";
+        }
+
+        var e = activeHint.e,
+            res;
+
+        /* process form actions like focus toggling inputs */
+        if (config.handleForm) {
+            res = handleForm(e);
+        }
+
+        if (config.keepOpen) {
+            /* reset the filter number */
+            filterNum = 0;
+            show(false);
+        } else {
+            clear();
+        }
+
+        return res || config.action(e);
+    }
+
+    /* focus or toggle form fields */
+    function handleForm(e) {
+        var tag  = e.nodeName.toLowerCase(),
+            type = e.type || "";
+
+        if (tag === "input" || tag === "textarea" || tag === "select") {
+            if (type === "radio" || type === "checkbox") {
+                e.focus();
+                click(e);
+                return "DONE:";
+            }
+            if (type === "submit" || type === "reset" || type  === "button" || type === "image") {
+                click(e);
+                return "DONE:";
+            }
+            e.focus();
+            return "INSERT:";
+        }
+        if (tag === "iframe" || tag === "frame") {
+            e.focus();
+            return "DONE:";
+        }
+    }
+
+    /* internal used methods */
+    function open(e, newWin) {
+        var oldTarget = e.target;
+        if (newWin) {
+            /* set target to open in new window */
+            e.target = "_blank";
+        } else if (e.target === "_blank") {
+            e.removeAttribute("target");
+        }
+        /* to open links in new window the mouse events are fired with ctrl */
+        /* key - otherwise some ugly pages will ignore this attribute in their */
+        /* mouse event observers like duckduckgo */
+        click(e, newWin);
+        e.target = oldTarget;
+    }
+
+    /* set focus on hint with given index valid hints array */
+    function focusHint(newIdx) {
+        /* reset previous focused hint */
+        if (activeHint) {
+            activeHint.e.classList.remove(fClass);
+            activeHint.label.classList.remove(fClass);
+            mouseEvent(activeHint.e, "mouseout");
+        }
+        /* get the new active hint */
+        if ((activeHint = validHints[newIdx])) {
+            activeHint.e.classList.add(fClass);
+            activeHint.label.classList.add(fClass);
+            mouseEvent(activeHint.e, "mouseover");
+
+            return "OVER:" + getSrc(activeHint.e);;
+        }
+    }
+
+    function click(e, ctrl) {
+        mouseEvent(e, "mouseover", ctrl);
+        mouseEvent(e, "mousedown", ctrl);
+        mouseEvent(e, "mouseup", ctrl);
+        mouseEvent(e, "click", ctrl);
+    }
+
+    function mouseEvent(e, name, ctrl) {
+        var evObj = e.ownerDocument.createEvent("MouseEvents");
+        evObj.initMouseEvent(
+            name, true, true, e.ownerDocument.defaultView,
+            0, 0, 0, 0, 0,
+            (typeof ctrl != "undefined") ? ctrl : false, false, false, false, 0, null
+        );
+        e.dispatchEvent(evObj);
+    }
+
+    /* retrieves the url of given element */
+    function getSrc(e) {
+        return e.href || e.src || "";
+    }
+
+    function xpath(doc, expr) {
+        return doc.evaluate(
+            expr, doc, function (p) {return "http://www.w3.org/1999/xhtml";},
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null
+        );
+    }
+
+    function allFrames(win) {
+        var i, f, frames = [win];
+        for (i = 0; i < win.frames.length; i++) {
+            frames.push(win.frames[i].frameElement);
+        }
+        return frames;
+    }
+
+    /* the api */
+    return {
+        init: function init(mode, keepOpen, maxHints, hintKeys, followLast, hintNumSameLength) {
+            var prop,
+                /* holds the xpaths for the different modes */
+                xpathmap = {
+                    otY:     "//*[@href] | //*[@onclick or @tabindex or @class='lk' or @role='link' or @role='button'] | //input[not(@type='hidden' or @disabled or @readonly)] | //textarea[not(@disabled or @readonly)] | //button | //select",
+                    e:       "//input[not(@type) or @type='text'] | //textarea",
+                    iI:      "//img[@src]",
+                    OpPsTxy: "//*[@href] | //img[@src and not(ancestor::a)] | //iframe[@src]"
+                },
+                /* holds the actions to perform on hint fire */
+                actionmap = {
+                    o:          function(e) {open(e, false); return "DONE:";},
+                    t:          function(e) {open(e, true); return "DONE:";},
+                    eiIOpPsTxy: function(e) {return "DATA:" + getSrc(e);},
+                    Y:          function(e) {return "DATA:" + (e.textContent || "");}
+                };
+
+            config = {
+                maxHints:   maxHints,
+                keepOpen:   keepOpen,
+                /* handle forms only useful when there are form fields in xpath */
+                /* don't handle form for Y to allow to yank form filed content */
+                /* instead of switching to input mode */
+                handleForm:        ("eot".indexOf(mode) >= 0),
+                hintKeys:          hintKeys,
+                followLast:        followLast,
+                hintNumSameLength: hintNumSameLength,
+            };
+            for (prop in xpathmap) {
+                if (prop.indexOf(mode) >= 0) {
+                    config["xpath"] = xpathmap[prop];
+                    break;
+                }
+            }
+            for (prop in actionmap) {
+                if (prop.indexOf(mode) >= 0) {
+                    config["action"] = actionmap[prop];
+                    break;
+                }
+            }
+
+            create();
+            return show(true);
+        },
+        filter: function filter(text) {
+            /* remove previously set number filters to make the filter */
+            /* easier to understand for the users */
+            filterNum  = 0;
+            filterText = text || "";
+            return show(true);
+        },
+        update: function update(n) {
+            var pos,
+                keys = config.hintKeys;
+            /* delete last filter number digit */
+            if (null === n && filterNum) {
+                filterNum = Math.floor(filterNum / keys.length);
+                return show(false);
+            }
+            if ((pos = keys.indexOf(n)) >= 0) {
+                filterNum = filterNum * keys.length + pos;
+                return show(true);
+            }
+            return "ERROR:";
+        },
+        clear:        clear,
+        fire:         fire,
+        focus:        focus,
+    };
+})());
+
+function testHint() {
+    console.log("harmless testing!");
+    /* hints.init('t', false, 500, '', false, false); */
+}

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -397,18 +397,15 @@ var hints = Object.freeze((function(){
 
     /* internal used methods */
     function open(e, newWin) {
-        var oldTarget = e.target;
-        if (newWin) {
-            /* set target to open in new window */
-            e.target = "_blank";
-        } else if (e.target === "_blank") {
-            e.removeAttribute("target");
+        if (newWin && e.hasAttribute('href')) {
+            /* Since the "noopener" vulnerability thing, it's not possible to set an anchor's
+             * target to _blank. Therefore, we can't simulate ctrl-click through _blank like we
+             * used to. Therefore, we limit ourselves to "window.open()" in cases we're firing a
+             * simple <a> link. In other cases, we fire the even normally.
+             */
+             window.open(e.getAttribute('href'), '_blank');
         }
-        /* to open links in new window the mouse events are fired with ctrl */
-        /* key - otherwise some ugly pages will ignore this attribute in their */
-        /* mouse event observers like duckduckgo */
-        click(e, newWin);
-        e.target = oldTarget;
+        click(e);
     }
 
     /* set focus on hint with given index valid hints array */
@@ -424,24 +421,22 @@ var hints = Object.freeze((function(){
             activeHint.e.classList.add(fClass);
             activeHint.label.classList.add(fClass);
             mouseEvent(activeHint.e, "mouseover");
-
-            return "OVER:" + getSrc(activeHint.e);;
         }
     }
 
-    function click(e, ctrl) {
-        mouseEvent(e, "mouseover", ctrl);
-        mouseEvent(e, "mousedown", ctrl);
-        mouseEvent(e, "mouseup", ctrl);
-        mouseEvent(e, "click", ctrl);
+    function click(e) {
+        mouseEvent(e, "mouseover");
+        mouseEvent(e, "mousedown");
+        mouseEvent(e, "mouseup");
+        mouseEvent(e, "click");
     }
 
-    function mouseEvent(e, name, ctrl) {
+    function mouseEvent(e, name) {
         var evObj = e.ownerDocument.createEvent("MouseEvents");
         evObj.initMouseEvent(
             name, true, true, e.ownerDocument.defaultView,
             0, 0, 0, 0, 0,
-            (typeof ctrl != "undefined") ? ctrl : false, false, false, false, 0, null
+            false, false, false, false, 0, null
         );
         e.dispatchEvent(evObj);
     }

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -538,8 +538,3 @@ var hints = Object.freeze((function(){
         focus:        focus,
     };
 })());
-
-function testHint() {
-    console.log("harmless testing!");
-    hints.init('t', false, 500, '0123456789', false, false);
-}

--- a/src/scripts/js2h.sh
+++ b/src/scripts/js2h.sh
@@ -32,7 +32,8 @@ sed -e 's:/\*[^*]*\*/::g' \
 # ecaspe
 sed -e 's|\\x20| |g' \
     -e 's|\\|\\\\|g' \
-    -e 's|"|\\"|g' | \
+    -e 's|"|\\"|g' \
+    -e 's|HINT_CSS|" HINT_CSS "|' | \
 # write opener with the starting and ending quote char
 sed -e "1s/^/#define $CONSTANT \"/" \
     -e '$s/$/"\n/'

--- a/src/setting.c
+++ b/src/setting.c
@@ -87,6 +87,7 @@ void setting_init(Client *c)
     setting_add(c, "fontsize", TYPE_INTEGER, &i, webkit, 0, "default-font-size");
     setting_add(c, "frame-flattening", TYPE_BOOLEAN, &off, webkit, 0, "enable-frame-flattening");
     setting_add(c, "header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, "header");
+    i = 1000;
     setting_add(c, "hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
     setting_add(c, "hintkeys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
     setting_add(c, "hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);

--- a/src/setting.c
+++ b/src/setting.c
@@ -87,6 +87,10 @@ void setting_init(Client *c)
     setting_add(c, "fontsize", TYPE_INTEGER, &i, webkit, 0, "default-font-size");
     setting_add(c, "frame-flattening", TYPE_BOOLEAN, &off, webkit, 0, "enable-frame-flattening");
     setting_add(c, "header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, "header");
+    setting_add(c, "hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
+    setting_add(c, "hintkeys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
+    setting_add(c, "hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);
+    setting_add(c, "hint-number-same-length", TYPE_BOOLEAN, &off, NULL, 0, NULL);
     setting_add(c, "html5-database", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-database");
     setting_add(c, "html5-local-storage", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-local-storage");
     setting_add(c, "hyperlink-auditing", TYPE_BOOLEAN, &off, webkit, 0, "enable-hyperlink-auditing");


### PR DESCRIPTION
This PR brings back the old `hints.c` from the `master` branch and adapts it to the webkit2 branch. This fixes #349. From my tests, most of the things work fine, with some notable exceptions:

### Open in a new window

As I wrote at https://github.com/fanglingsu/vimb/issues/349#issuecomment-298469136 , I couldn't get the old trick (dynamically adding `target="_blank"` to the element before simulating the click) to work on webkit2 because now, when we try to set `target` to `_blank` in JS, it sets it to `null`. I think that it was done to address the [window opener vulnerability](https://mathiasbynens.github.io/rel-noopener/).

I went with a simpler approach: `window.open()`. It works for simple links, but for more complex elements (buttons that trigger JS when clicked), that's not going to work. When that happens (when there's no `href` attribute), we simply revert to the `;o` behavior.

### Editor command (;e)

I haven't implemented it. I'm already knee-deep in complexity I don't master well, I'd be more comfortable implementing this after a first merge of this original code.

EDIT: oh, I see that it was *already* part of a separate issue (#347)

### Follow link under search pattern

This is unrelated to hinting, but was implemented in `hints.c` in the `master` branch. I have commented this part and suggest that we re-implement it separately, in another unit.