### PR TITLE
hints: open links in async mode

### DIFF
--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -384,15 +384,23 @@ var hints = Object.freeze((function(){
 
     /* internal used methods */
     function open(e, newWin) {
+        /* We call open() and click() in async mode to avoid return as fast as possible.
+         * If we don't return immediately, the EvalJS dbus call will probably timeout and cause
+         * errors.
+         */
         if (newWin && e.hasAttribute('href')) {
             /* Since the "noopener" vulnerability thing, it's not possible to set an anchor's
              * target to _blank. Therefore, we can't simulate ctrl-click through _blank like we
              * used to. Therefore, we limit ourselves to "window.open()" in cases we're firing a
              * simple <a> link. In other cases, we fire the even normally.
              */
-             window.open(e.getAttribute('href'), '_blank');
+
+            window.setTimeout(function() {
+                window.open(e.getAttribute('href'), '_blank');
+                }, 0
+            );
         }
-        e.click();
+        window.setTimeout(function() {e.click();}, 0);
     }
 
     /* set focus on hint with given index valid hints array */


### PR DESCRIPTION
When firing hints, open them (either by simulating a click or through
`window.open()`) in async mode with `window.setTimeout()`. If we don't
do that, the `EvalJS` dbus call will itself timeout and we'll end up
in an inconsistent state, that is, not back to Normal mode.

ref #349