### PR TITLE
hintElem opacity for non opaque elements

### DIFF
--- a/src/scripts/hints.css
+++ b/src/scripts/hints.css
@@ -17,7 +17,8 @@
     background-color:#ff0 !important;
     color:#000 !important;
     transition-delay:all 0 !important;
-    transition:all 0 !important
+    transition:all 0 !important;
+    opacity:1 !important
 }
 ._hintElem._hintFocus{
     background-color:#8f0 !important


### PR DESCRIPTION
Forces the hintElem to be fully opaque, even when attached to non opaque
elements (e.g. ```{opacity:0.5}```). #349