### PR TITLE
setting: expose hardware acceleration settings

### DIFF
--- a/src/setting.c
+++ b/src/setting.c
@@ -54,6 +54,7 @@ static int cookie_accept(Client *c, const char *name, DataType type, void *value
 static int default_zoom(Client *c, const char *name, DataType type, void *value, void *data);
 static int fullscreen(Client *c, const char *name, DataType type, void *value, void *data);
 static int gui_style(Client *c, const char *name, DataType type, void *value, void *data);
+static int hardware_acceleration_policy(Client *c, const char *name, DataType type, void *value, void *data);
 static int input_autohide(Client *c, const char *name, DataType type, void *value, void *data);
 static int internal(Client *c, const char *name, DataType type, void *value, void *data);
 static int headers(Client *c, const char *name, DataType type, void *value, void *data);
@@ -81,6 +82,7 @@ void setting_init(Client *c)
     setting_add(c, "useragent", TYPE_CHAR, &"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/603.1 (KHTML, like Gecko) " PROJECT "/" VERSION " Version/10.0 Safari/603.1", webkit, 0, "user-agent");
     /* TODO use the real names for webkit settings */
     i = 14;
+    setting_add(c, "accelerated-2d-canvas", TYPE_BOOLEAN, &off, webkit, 0, "enable-accelerated-2d-canvas");
     setting_add(c, "caret", TYPE_BOOLEAN, &off, webkit, 0, "enable-caret-browsing");
     setting_add(c, "cursiv-font", TYPE_CHAR, &"serif", webkit, 0, "cursive-font-family");
     setting_add(c, "default-charset", TYPE_CHAR, &"utf-8", webkit, 0, "default-charset");
@@ -89,6 +91,7 @@ void setting_init(Client *c)
     i = SETTING_DEFAULT_FONT_SIZE;
     setting_add(c, "font-size", TYPE_INTEGER, &i, webkit, 0, "default-font-size");
     setting_add(c, "frame-flattening", TYPE_BOOLEAN, &off, webkit, 0, "enable-frame-flattening");
+    setting_add(c, "hardware-acceleration-policy", TYPE_CHAR, &"ondemand", hardware_acceleration_policy, FLAG_NODUP, NULL);
     setting_add(c, "header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, "header");
     i = 1000;
     setting_add(c, "hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
@@ -535,6 +538,24 @@ static int fullscreen(Client *c, const char *name, DataType type, void *value, v
         gtk_window_fullscreen(GTK_WINDOW(c->window));
     } else {
         gtk_window_unfullscreen(GTK_WINDOW(c->window));
+    }
+
+    return CMD_SUCCESS;
+}
+
+static int hardware_acceleration_policy(Client *c, const char *name, DataType type, void *value, void *data)
+{
+    WebKitSettings *settings = webkit_web_view_get_settings(c->webview);
+
+    if (g_str_equal(value, "ondemand")) {
+        webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
+    } else if (g_str_equal(value, "always")) {
+        webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
+    } else if (g_str_equal(value, "never")) {
+        webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
+    } else {
+        vb_echo(c, MSG_ERROR, TRUE, "%s must be in [ondemand, always, never]", name);
+        return CMD_ERROR|CMD_KEEPINPUT;
     }
 
     return CMD_SUCCESS;


### PR DESCRIPTION
Previous to the migration to the WebKit 2 API, we were exposing settings
to enable hardware acceleration for compositing via
"accelerated-compositing". With WebKit 2, there are two relevant
settings to enable compositing. The "hardware-acceleration_policy" is
used to determine when the rendering process should actually use
hardware acceleration. "accelerated-2d-canvas" enables hardware
acceleration for some 2D canvas content if WebKitGTK+ is built with
Cairo and its unstable CairoGL API.

Thes patch exposes both of these settings via vimb's settings engine.