### PR TITLE
scroll: fix percent-based scrolling

### DIFF
--- a/src/scripts/scroll.js
+++ b/src/scripts/scroll.js
@@ -2,7 +2,7 @@ function vbscroll(mode, scrollStep, count) {
     var w = window,
         d = document,
         x = y = 0,
-        ph = d.documentElement.clientHeight,
+        ph = w.innerHeight,
         c = count||1,
         rel = true;
     switch (mode) {


### PR DESCRIPTION
Scrolling via ^D and ^U should scroll by a percentage of the client's
current viewport. We do this in JavaScript via the client height of the
document's element. Accidentally, it may hold the desired value in some
cases, but in general it only holds the total height of the element
itself. What we desire instead is the window's height, which can be
retrieved via `Window.innerHeight`. Like this, our calculations are not
based upon the webpage but instead on the browser window, fixing
scrolling on some pages.