### PR TITLE
Hints without JavaScript

### DIFF
--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -387,15 +387,19 @@ var hints = Object.freeze((function(){
         /* We call open() and click() in async mode to avoid return as fast as possible. */
         /* If we don't return immediately, the EvalJS dbus call will probably timeout and cause */
         /* errors. */
-        if (newWin && e.hasAttribute('href')) {
-            /* Since the "noopener" vulnerability thing, it's not possible to set an anchor's */
-            /* target to _blank. Therefore, we can't simulate ctrl-click through _blank like we */
-            /* used to. Therefore, we limit ourselves to "window.open()" in cases we're firing a */
-            /* simple <a> link. In other cases, we fire the even normally. */
-            window.setTimeout(function() {
-                window.open(e.getAttribute('href'), '_blank');
-                }, 0
-            );
+        if (e.hasAttribute('href')) {
+            if (newWin) {
+                /* Since the "noopener" vulnerability thing, it's not possible to set an anchor's */
+                /* target to _blank. Therefore, we can't simulate ctrl-click through _blank like we */
+                /* used to. Therefore, we limit ourselves to "window.open()" in cases we're firing a */
+                /* simple <a> link. In other cases, we fire the even normally. */
+                window.setTimeout(function() {
+                    window.open(e.getAttribute('href'), '_blank');
+                    }, 0
+                );
+            } else {
+                window.location.href = e.getAttribute('href');
+            }
         }
         window.setTimeout(function() {e.click();}, 0);
     }

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -400,8 +400,9 @@ var hints = Object.freeze((function(){
             } else {
                 window.location.href = e.getAttribute('href');
             }
+        } else {
+            window.setTimeout(function() {e.click();}, 0);
         }
-        window.setTimeout(function() {e.click();}, 0);
     }
 
     /* set focus on hint with given index valid hints array */


### PR DESCRIPTION
Two issues are solved by this PR:

- we now use `window.location.href = e.href` when the target elment has the href attribute instead of using `click()`. This allows us to use hinting even with JavaScript disabled.
- second, it solves the issue of setting both current and new window's URL to the target URL when trying to open a new window via hints. This was caused by a missing return or else branch in our `open` function, causing us to first use `window.open` and then `e.click()`.