### PR TITLE
improve hint char selection

### DIFF
--- a/src/setting.c
+++ b/src/setting.c
@@ -98,7 +98,7 @@ void setting_init(Client *c)
     setting_add(c, "header", TYPE_CHAR, &"", headers, FLAG_LIST|FLAG_NODUP, "header");
     i = 1000;
     setting_add(c, "hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
-    setting_add(c, "hint-keys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
+    setting_add(c, "hint-keys", TYPE_CHAR, &"1234567890", NULL, 0, NULL);
     setting_add(c, "hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);
     setting_add(c, "hint-number-same-length", TYPE_BOOLEAN, &off, NULL, 0, NULL);
     setting_add(c, "html5-database", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-database");

--- a/tests/manual/hints.html
+++ b/tests/manual/hints.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+<title>hints</title>
+</head>
+<body>
+  <ul>
+    <li><a href="https://github.com">a href site 0</a></li>
+    <li><a href="https://github.com">a href site 1</a></li>
+    <li><a href="https://github.com">a href site 2</a></li>
+    <li><a href="https://github.com">a href site 3</a></li>
+    <li><a href="https://github.com">a href site 4</a></li>
+    <li><a href="https://github.com">a href site 5</a></li>
+    <li><a href="https://github.com">a href site 6</a></li>
+    <li><a href="https://github.com">a href site 7</a></li>
+    <li><a href="https://github.com">a href site 8</a></li>
+    <li><a href="https://github.com">a href site 9</a></li>
+    <li><a href="#0">a href anchor 0</a></li>
+    <li><a href="#1">a href anchor 1</a></li>
+    <li><a href="#2">a href anchor 2</a></li>
+    <li><a href="#3">a href anchor 3</a></li>
+    <li><a href="#4">a href anchor 4</a></li>
+    <li><a href="#5">a href anchor 5</a></li>
+    <li><a href="#6">a href anchor 6</a></li>
+    <li><a href="#7">a href anchor 7</a></li>
+    <li><a href="#8">a href anchor 8</a></li>
+    <li><a href="#9">a href anchor 9</a></li>
+  </ul>
+</body>
+</html>
+


### PR DESCRIPTION
Improves the hint char selection, especially for ```hint-keys``` settings other than the default (e.g. ```set hint-keys=asdfg;lkjh``` as suggested in the man page)

### Before
Until now the ```hint-keys``` string was used in a way that the default ```0123456789``` string generated nice decimal numbers as expected: ```1 2 3 4 5 6 7 8 9 10 11 12 13 14 15```

But setting it to something different, such as ```12345```, if you want to use only the left hand to select hints, generated somewhat strange results: ```2 3 4 5 21 22 23 24 25 31 32 33 34 35 41``` 

Same happened with the suggested home row setting from the man page: ```s d f g ; l k j h sa ss sd sf sg s;```

The first char, the ```1``` or ```a``` was never used as a leading hint character. This actually wasted it and created unnecessarily long hints.

### This patch
- Makes use of the first character as a leading hint char as well
- Therefore creates somewhat shorter hint strings
- Stays very close to the default behaviour when using the default ```hint-keys``` setting

#### The new default 1234567890
```1 2 3 4 5 6 7 8 9 0 11 12 13 14 15``` 

#### Left hand mode 12345
```1 2 3 4 5 11 12 13 14 15 21 22 23 24 25```

#### Home row mode asdfg;lkjh
```a s d f g ; l k j h aa as ad af ag```

