### PR TITLE
history: skip adding items if history is disabled

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -55,13 +55,10 @@ void history_add(Client *c, HistoryType type, const char *value, const char *add
 {
     const char *file;
 
-#if 0
-    /* Don't write a history entry if the history max size is set to 0. Else
-     * skip command history in case the command was not typed by the user. */
-    if (!vb.config.history_max || (!vb.state.typed && type == HISTORY_COMMAND)) {
+    /* Don't write a history entry if the history max size is set to 0. */
+    if (!vb.config.history_max) {
         return;
     }
-#endif
 
     file = HIST_FILE(type);
     if (additional) {


### PR DESCRIPTION
Previous to the migration to webkit2gtk, history items were not added
when either "history-max-items" was set to "0" or if a command was not
inserted by typing, but for example triggered by "au" commands. Right
now, though, this code is #ifdef'd out, so we'll always add items to the
history.

While we currently have no easy way of determining whether a command was
typed or not, we should still refuse adding history items whenever the
"history-max-items" variable is set to "0". As "au"-triggered commands
are not yet supported again, we do not even have to worry about this
case right now, but only later on when it is added. So we fix the issue
now by returning early when `history_max` is not set.