### PR TITLE
Fix dbus timeout in hinting of anchors

### DIFF
--- a/src/bookmark.c
+++ b/src/bookmark.c
@@ -59,10 +59,10 @@ gboolean bookmark_remove(const char *uri)
     char **lines, *line, *p;
     int len, i;
     GString *new;
-    gboolean removed = false;
+    gboolean removed = FALSE;
 
     if (!uri) {
-        return false;
+        return FALSE;
     }
 
     lines = util_get_lines(vb.files[FILES_BOOKMARK]);
@@ -76,7 +76,7 @@ gboolean bookmark_remove(const char *uri)
             if ((p = strchr(line, '\t'))) {
                 *p = '\0';
                 if (!strcmp(uri, line)) {
-                    removed = true;
+                    removed = TRUE;
                     continue;
                 } else {
                     /* reappend the tags */
@@ -84,14 +84,14 @@ gboolean bookmark_remove(const char *uri)
                 }
             }
             if (!strcmp(uri, line)) {
-                removed = true;
+                removed = TRUE;
                 continue;
             }
             g_string_append_printf(new, "%s\n", line);
         }
         g_strfreev(lines);
         g_file_set_contents(vb.files[FILES_BOOKMARK], new->str, -1, NULL);
-        g_string_free(new, true);
+        g_string_free(new, TRUE);
     }
 
     return removed;
@@ -99,7 +99,7 @@ gboolean bookmark_remove(const char *uri)
 
 gboolean bookmark_fill_completion(GtkListStore *store, const char *input)
 {
-    gboolean found = false;
+    gboolean found = FALSE;
     char **parts;
     unsigned int len;
     GtkTreeIter iter;
@@ -121,7 +121,7 @@ gboolean bookmark_fill_completion(GtkListStore *store, const char *input)
 #endif
                 -1
             );
-            found = true;
+            found = TRUE;
         }
     } else {
         parts = g_strsplit(input, " ", 0);
@@ -139,7 +139,7 @@ gboolean bookmark_fill_completion(GtkListStore *store, const char *input)
 #endif
                     -1
                 );
-                found = true;
+                found = TRUE;
             }
         }
         g_strfreev(parts);
@@ -228,9 +228,9 @@ gboolean bookmark_queue_clear(void)
     FILE *f;
     if ((f = fopen(vb.files[FILES_QUEUE], "w"))) {
         fclose(f);
-        return true;
+        return TRUE;
     }
-    return false;
+    return FALSE;
 }
 #endif /* FEATURE_QUEUE */
 
@@ -247,7 +247,7 @@ static GList *load(const char *file)
  * @query: char array with tags to search for
  * @qlen:  length of given query char array
  *
- * Return: true if the bookmark contained all tags
+ * Return: TRUE if the bookmark contained all tags
  */
 static gboolean bookmark_contains_all_tags(Bookmark *bm, char **query,
     unsigned int qlen)
@@ -258,7 +258,7 @@ static gboolean bookmark_contains_all_tags(Bookmark *bm, char **query,
     gboolean found;
 
     if (!qlen) {
-        return true;
+        return TRUE;
     }
 
     if (bm->tags) {
@@ -273,7 +273,7 @@ static gboolean bookmark_contains_all_tags(Bookmark *bm, char **query,
 
     /* iterate over all query parts */
     for (i = 0; i < qlen; i++) {
-        found = false;
+        found = FALSE;
 
         /* we want to do a prefix match on all bookmark tags - so we check for
          * a match on string begin - if this fails we move the cursor to the
@@ -281,7 +281,7 @@ static gboolean bookmark_contains_all_tags(Bookmark *bm, char **query,
         while (cursor && *cursor) {
             /* match was not found at current cursor position */
             if (g_str_has_prefix(cursor, query[i])) {
-                found = true;
+                found = TRUE;
                 break;
             }
             /* If match was not found at the cursor position - move cursor
@@ -292,11 +292,11 @@ static gboolean bookmark_contains_all_tags(Bookmark *bm, char **query,
         }
 
         if (!found) {
-            return false;
+            return FALSE;
         }
     }
 
-    return true;
+    return TRUE;
 }
 
 static Bookmark *line_to_bookmark(const char *uri, const char *data)

--- a/src/command.c
+++ b/src/command.c
@@ -173,7 +173,7 @@ gboolean command_yank(Client *c, const Arg *arg, char buf)
     /* store in X "windows style" clipboard */
     gtk_clipboard_set_text(gtk_clipboard_get(GDK_SELECTION_CLIPBOARD), yanked, -1);
 
-    vb_echo(c, MSG_NORMAL, false, "Yanked: %s", yanked);
+    vb_echo(c, MSG_NORMAL, FALSE, "Yanked: %s", yanked);
 
     g_free(yanked);
 

--- a/src/ex.c
+++ b/src/ex.c
@@ -467,7 +467,7 @@ VbCmdResult ex_run_file(Client *c, const char *filename)
         if (*line == '#' || !*line) {
             continue;
         }
-        if ((ex_run_string(c, line, false) & ~CMD_KEEPINPUT) == CMD_ERROR) {
+        if ((ex_run_string(c, line, FALSE) & ~CMD_KEEPINPUT) == CMD_ERROR) {
             res = CMD_ERROR | CMD_KEEPINPUT;
             g_warning("Invalid command in %s: '%s'", filename, line);
         }
@@ -1059,7 +1059,7 @@ static VbCmdResult ex_handlers(Client *c, const ExArg *arg)
 static VbCmdResult ex_shortcut(Client *c, const ExArg *arg)
 {
     gchar *uri;
-    gboolean success = false;
+    gboolean success = FALSE;
 
     if (!c) {
         return CMD_ERROR;

--- a/src/handler.c
+++ b/src/handler.c
@@ -44,7 +44,7 @@ gboolean handler_add(Client *c, const char *key, const char *cmd)
 {
     g_hash_table_insert(c->handlers.table, g_strdup(key), g_strdup(cmd));
 
-    return true;
+    return TRUE;
 }
 
 gboolean handler_remove(Client *c, const char *key)

--- a/src/hints.c
+++ b/src/hints.c
@@ -38,6 +38,7 @@ static struct {
     /* holds the setting if JavaScript can open windows automatically that we
      * have to change to open windows via hinting */
     gboolean       allow_open_win;
+    gboolean       allow_javascript;
     guint          timeout_id;
 } hints;
 
@@ -90,9 +91,12 @@ void hints_clear(Client *c)
         call_hints_function(c, "clear", "true");
 
         /* if open window was not allowed for JavaScript, restore this */
+        WebKitSettings *setting = webkit_web_view_get_settings(c->webview);
         if (!hints.allow_open_win) {
-            WebKitSettings *setting = webkit_web_view_get_settings(c->webview);
             g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", hints.allow_open_win, NULL);
+        }
+        if (!hints.allow_javascript) {
+            g_object_set(G_OBJECT(setting), "enable-javascript", hints.allow_javascript, NULL);
         }
     }
 }
@@ -117,11 +121,21 @@ void hints_create(Client *c, const char *input)
 
         /* before we enable JavaScript to open new windows, we save the actual
          * value to be able restore it after hints where fired */
-        g_object_get(G_OBJECT(setting), "javascript-can-open-windows-automatically", &(hints.allow_open_win), NULL);
+        g_object_get(G_OBJECT(setting),
+                "javascript-can-open-windows-automatically", &(hints.allow_open_win),
+                "enable-javascript", &(hints.allow_javascript),
+                NULL);
 
         /* if window open is already allowed there's no need to allow it again */
         if (!hints.allow_open_win) {
             g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", true, NULL);
+        }
+        /* TODO This might be a security issue to toggle JavaScript
+         * temporarily on. */
+        /* This is a hack to allow window.setTimeout() and scroll observers in
+         * hinting script which does not work when JavaScript is disabled. */
+        if (!hints.allow_javascript) {
+            g_object_set(G_OBJECT(setting), "enable-javascript", true, NULL);
         }
 
         hints.promptlen = hints.gmode ? 3 : 2;

--- a/src/hints.c
+++ b/src/hints.c
@@ -60,29 +60,29 @@ VbResult hints_keypress(Client *c, int key)
 
         return RESULT_COMPLETE;
     } else if (key == CTRL('H')) { /* backspace */
-        fire_timeout(c, false);
+        fire_timeout(c, FALSE);
         if (call_hints_function(c, "update", "null", TRUE)) {
             return RESULT_COMPLETE;
         }
     } else if (key == KEY_TAB) {
-        fire_timeout(c, false);
-        hints_focus_next(c, false);
+        fire_timeout(c, FALSE);
+        hints_focus_next(c, FALSE);
 
         return RESULT_COMPLETE;
     } else if (key == KEY_SHIFT_TAB) {
-        fire_timeout(c, false);
-        hints_focus_next(c, true);
+        fire_timeout(c, FALSE);
+        hints_focus_next(c, TRUE);
 
         return RESULT_COMPLETE;
     } else {
-        fire_timeout(c, true);
+        fire_timeout(c, TRUE);
         /* try to handle the key by the javascript */
         if (call_hints_function(c, "update", (char[]){'"', key, '"', '\0'}, TRUE)) {
             return RESULT_COMPLETE;
         }
     }
 
-    fire_timeout(c, false);
+    fire_timeout(c, FALSE);
     return RESULT_ERROR;
 }
 
@@ -94,7 +94,7 @@ void hints_clear(Client *c)
 
         /* Run this sync else we would disable JavaScript before the hint is
          * fired. */
-        call_hints_function(c, "clear", "true", TRUE);
+        call_hints_function(c, "clear", "TRUE", TRUE);
 
         /* if open window was not allowed for JavaScript, restore this */
         WebKitSettings *setting = webkit_web_view_get_settings(c->webview);
@@ -134,25 +134,25 @@ void hints_create(Client *c, const char *input)
 
         /* if window open is already allowed there's no need to allow it again */
         if (!hints.allow_open_win) {
-            g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", true, NULL);
+            g_object_set(G_OBJECT(setting), "javascript-can-open-windows-automatically", TRUE, NULL);
         }
         /* TODO This might be a security issue to toggle JavaScript
          * temporarily on. */
         /* This is a hack to allow window.setTimeout() and scroll observers in
          * hinting script which does not work when JavaScript is disabled. */
         if (!hints.allow_javascript) {
-            g_object_set(G_OBJECT(setting), "enable-javascript", true, NULL);
+            g_object_set(G_OBJECT(setting), "enable-javascript", TRUE, NULL);
         }
 
         hints.promptlen = hints.gmode ? 3 : 2;
 
         jsargs = g_strdup_printf("'%s', %s, %d, '%s', %s, %s",
             (char[]){hints.mode, '\0'},
-            hints.gmode ? "true" : "false",
+            hints.gmode ? "TRUE" : "false",
             MAXIMUM_HINTS,
             GET_CHAR(c, "hint-keys"),
-            GET_BOOL(c, "hint-follow-last") ? "true" : "false",
-            GET_BOOL(c, "hint-number-same-length") ? "true" : "false"
+            GET_BOOL(c, "hint-follow-last") ? "TRUE" : "false",
+            GET_BOOL(c, "hint-number-same-length") ? "TRUE" : "false"
         );
 
         call_hints_function(c, "init", jsargs, FALSE);
@@ -170,7 +170,7 @@ void hints_create(Client *c, const char *input)
 
 void hints_focus_next(Client *c, const gboolean back)
 {
-    call_hints_function(c, "focus", back ? "true" : "false", FALSE);
+    call_hints_function(c, "focus", back ? "TRUE" : "false", FALSE);
 }
 
 void hints_fire(Client *c)
@@ -235,7 +235,7 @@ gboolean hints_parse_prompt(const char *prompt, char *mode, gboolean *is_gmode)
 #endif
 
     if (!prompt) {
-        return false;
+        return FALSE;
     }
 
     /* get the mode identifying char from prompt */
@@ -248,7 +248,7 @@ gboolean hints_parse_prompt(const char *prompt, char *mode, gboolean *is_gmode)
 
     /* no mode found in prompt */
     if (!pmode) {
-        return false;
+        return FALSE;
     }
 
     res = *prompt == 'g'
@@ -313,7 +313,7 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
 
     /* following return values mark fired hints */
     if (!strncmp(value, "DONE:", 5)) {
-        fire_timeout(c, false);
+        fire_timeout(c, FALSE);
         /* Change to normal mode only if we are currently in command mode and
          * we are not in g-mode hinting. This is required to not switch to
          * normal mode when the hinting triggered a click that set focus on
@@ -329,13 +329,13 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
             c->mode->flags |= FLAG_NEW_WIN;
         }
     } else if (!strncmp(value, "INSERT:", 7)) {
-        fire_timeout(c, false);
+        fire_timeout(c, FALSE);
         vb_enter(c, 'i');
         if (hints.mode == 'e') {
             input_open_editor(c);
         }
     } else if (!strncmp(value, "DATA:", 5)) {
-        fire_timeout(c, false);
+        fire_timeout(c, FALSE);
         /* switch first to normal mode - else we would clear the inputbox
          * on switching mode also if we want to show yanked data */
         if (!hints.gmode) {
@@ -357,7 +357,7 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
 
             case 'O':
             case 'T':
-                vb_echo(c, MSG_NORMAL, false, "%s %s", (hints.mode == 'T') ? ":tabopen" : ":open", v);
+                vb_echo(c, MSG_NORMAL, FALSE, "%s %s", (hints.mode == 'T') ? ":tabopen" : ":open", v);
                 if (!hints.gmode) {
                     vb_enter(c, 'c');
                 }
@@ -370,7 +370,7 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
                 break;
 
             case 'x':
-                map_handle_string(c, GET_CHAR(c, "x-hint-command"), true);
+                map_handle_string(c, GET_CHAR(c, "x-hint-command"), TRUE);
                 break;
 
             case 'y':
@@ -418,5 +418,5 @@ static gboolean fire_cb(gpointer data)
     /* remove timeout id for the timeout that is removed by return value of
      * false automatic */
     hints.timeout_id = 0;
-    return false;
+    return FALSE;
 }

--- a/src/input.c
+++ b/src/input.c
@@ -118,7 +118,7 @@ VbResult input_open_editor(Client *c)
     /* get the editor command */
     editor_command = GET_CHAR(c, "editor-command");
     if (!editor_command || !*editor_command) {
-        vb_echo(c, MSG_ERROR, true, "No editor-command configured");
+        vb_echo(c, MSG_ERROR, TRUE, "No editor-command configured");
         return RESULT_ERROR;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -857,7 +857,7 @@ static void on_textbuffer_changed(GtkTextBuffer *textbuffer, gpointer user_data)
     if (gtk_widget_is_focus(c->input) && c->mode && c->mode->input_changed) {
 
         gtk_text_buffer_get_bounds(textbuffer, &start, &end);
-        text = gtk_text_buffer_get_text(textbuffer, &start, &end, false);
+        text = gtk_text_buffer_get_text(textbuffer, &start, &end, FALSE);
 
         c->mode->input_changed(c, text);
 
@@ -898,7 +898,7 @@ static void set_title(Client *c, const char *title)
 {
     OVERWRITE_STRING(c->state.title, title);
     update_title(c);
-    g_setenv("VIMB_TITLE", title ? title : "", true);
+    g_setenv("VIMB_TITLE", title ? title : "", TRUE);
 }
 
 /**

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -361,7 +361,7 @@ var hints = Object.freeze((function(){
                 idx = 0;
             }
         }
-        return focusHint(idx);
+        focusHint(idx);
     }
 
     function fire() {

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -414,15 +414,17 @@ var hints = Object.freeze((function(){
 
     /* internal used methods */
     function open(e) {
-        var href;
-        if ((href = e.getAttribute('href')) && href != '#') {
-            window.location.href = href;
-        } else {
-            /* We call click() in async mode to return as fast as possible. If
-             * we don't return immediately, the EvalJS dbus call will probably
-             * timeout and cause errors. */
-            window.setTimeout(function() {e.click();}, 0);
-        }
+        /* We call click() in async mode to return as fast as possible. If
+         * we don't return immediately, the EvalJS dbus call will probably
+         * timeout and cause errors. */
+        window.setTimeout(function() {
+            var href;
+            if ((href = e.getAttribute('href')) && href != '#') {
+                window.location.href = href;
+            } else {
+                e.click();
+            }
+        }, 0);
     }
 
     /* set focus on hint with given index valid hints array */

--- a/src/util.c
+++ b/src/util.c
@@ -126,7 +126,7 @@ gboolean util_create_tmp_file(const char *content, char **file)
     if (fp == -1) {
         g_critical("Could not create temp file %s", *file);
         g_free(*file);
-        return false;
+        return FALSE;
     }
 
     len = strlen(content);
@@ -139,11 +139,11 @@ gboolean util_create_tmp_file(const char *content, char **file)
         g_critical("Could not write temp file %s", *file);
         g_free(*file);
 
-        return false;
+        return FALSE;
     }
     close(fp);
 
-    return true;
+    return TRUE;
 }
 
 /**
@@ -212,7 +212,7 @@ gboolean util_file_append(const char *file, const char *format, ...)
  */
 gboolean util_file_prepend(const char *file, const char *format, ...)
 {
-    gboolean res = false;
+    gboolean res = FALSE;
     va_list args;
     char *content;
     FILE *f;
@@ -235,7 +235,7 @@ gboolean util_file_prepend(const char *file, const char *format, ...)
         flock(fileno(f), LOCK_UN);
         fclose(f);
 
-        res = true;
+        res = TRUE;
     }
     g_free(content);
 
@@ -484,14 +484,14 @@ GList *util_file_to_unique_list(const char *filename, Util_Content_Func func,
  */
 gboolean util_fill_completion(GtkListStore *store, const char *input, GList *src)
 {
-    gboolean found = false;
+    gboolean found = FALSE;
     GtkTreeIter iter;
 
     if (!input || !*input) {
         for (GList *l = src; l; l = l->next) {
             gtk_list_store_append(store, &iter);
             gtk_list_store_set(store, &iter, COMPLETION_STORE_FIRST, l->data, -1);
-            found = true;
+            found = TRUE;
         }
     } else {
         for (GList *l = src; l; l = l->next) {
@@ -499,7 +499,7 @@ gboolean util_fill_completion(GtkListStore *store, const char *input, GList *src
             if (g_str_has_prefix(value, input)) {
                 gtk_list_store_append(store, &iter);
                 gtk_list_store_set(store, &iter, COMPLETION_STORE_FIRST, l->data, -1);
-                found = true;
+                found = TRUE;
             }
         }
     }

--- a/src/webextension/ext-main.c
+++ b/src/webextension/ext-main.c
@@ -217,7 +217,7 @@ static void add_onload_event_observers(WebKitDOMDocument *doc,
 
     /* Observe scroll events to get current position in the document. */
     webkit_dom_event_target_add_event_listener(target, "scroll",
-            G_CALLBACK(on_document_scroll), false, page);
+            G_CALLBACK(on_document_scroll), FALSE, page);
     /* Call the callback explicitly to make sure we have the right position
      * shown in statusbar also in cases the user does not scroll. */
     on_document_scroll(target, NULL, page);


### PR DESCRIPTION
In case the hinting opens a URL with a location hash in it, the syncronous dbus call for the hinting script timed out. After the timeout the right page was openend, but the UI process was not informed about that and the hinting was still active `;o` in statusbar #421. It seemed to be some JavaScript engin internal why URL with location hash behave so different.
Now the `open()` in the hinting script does it's logic in a `setTimout` which is something like running it in another thread so that we can return as soon as possible to send the data to the UI process. To allow the `setTimeout` usage JavaScript is enabled on starting hinting and is set back to the user defined value after that.

The UI logic of the hinting was also adapted to use assync dbus communication if this was possible. This does not help agains all the cases with the location hash in the hinted URL, but avoid unneeded blocking of the UI.