### PR TITLE
Rename hint-number-same-length into hint-keys-same-length #425

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   hinting is done might be security relevant.
 * Allow extended hints mode also for open `g;o` to allow the user to toggle
   checkboxes and radiobuttons of forms.
+* Rename `hint-number-same-length` into `hint-keys-same-length` for consistency.
 
 ### Fixed
 

--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -935,8 +935,8 @@ Header completely from request.
 If on, vimb automatically follows the last remaining hint on the page.
 If off hints are fired only if enter is pressed.
 .TP
-.B hint-number-same-length (bool)
-If on, all hint numbers will have the same length, so no hints will be
+.B hint-keys-same-length (bool)
+If on, all hint labels will have the same length, so no hints will be
 ambiguous.
 .TP
 .B hint-timeout (int)

--- a/src/hints.c
+++ b/src/hints.c
@@ -152,7 +152,7 @@ void hints_create(Client *c, const char *input)
             MAXIMUM_HINTS,
             GET_CHAR(c, "hint-keys"),
             GET_BOOL(c, "hint-follow-last") ? "true" : "false",
-            GET_BOOL(c, "hint-number-same-length") ? "true" : "false"
+            GET_BOOL(c, "hint-keys-same-length") ? "true" : "false"
         );
 
         call_hints_function(c, "init", jsargs, FALSE);

--- a/src/setting.c
+++ b/src/setting.c
@@ -96,7 +96,7 @@ void setting_init(Client *c)
     setting_add(c, "hint-timeout", TYPE_INTEGER, &i, NULL, 0, NULL);
     setting_add(c, "hint-keys", TYPE_CHAR, &"0123456789", NULL, 0, NULL);
     setting_add(c, "hint-follow-last", TYPE_BOOLEAN, &on, NULL, 0, NULL);
-    setting_add(c, "hint-number-same-length", TYPE_BOOLEAN, &off, NULL, 0, NULL);
+    setting_add(c, "hint-keys-same-length", TYPE_BOOLEAN, &off, NULL, 0, NULL);
     setting_add(c, "html5-database", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-database");
     setting_add(c, "html5-local-storage", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-local-storage");
     setting_add(c, "hyperlink-auditing", TYPE_BOOLEAN, &off, webkit, 0, "enable-hyperlink-auditing");


### PR DESCRIPTION
Just a small commit to get started with vimb codebase. It renames `hint-number-same-length` into `hint-keys-same-length` to fix #425.