### PR TITLE
n/N restart the previous search if none is active

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -643,6 +643,10 @@ static void client_destroy(Client *c)
         vb.clients = c->next;
     }
 
+    if (c->state.search.last_query) {
+        g_free(c->state.search.last_query);
+    }
+
     completion_cleanup(c);
     map_cleanup(c);
     register_cleanup(c);

--- a/src/main.h
+++ b/src/main.h
@@ -176,6 +176,7 @@ struct State {
         gboolean    active;         /* indicate if there is a active search */
         short       direction;      /* last direction 1 forward, -1 backward */
         int         matches;        /* number of matching search results */
+        char        *last_query;    /* last search query */
     } search;
 };
 


### PR DESCRIPTION
vimb no longer ignores n/N if no search is active. Instead, it restarts
a search with the same query that was used in the last search, just like
Vim does. This is very convenient when searching for the same query in
different pages.