### PR TITLE
history: add history item as soon as the load is committed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1313,6 +1313,10 @@ static void on_webview_load_changed(WebKitWebView *webview,
              * in case a link was fired from highlighted link. */
             command_search(c, &(Arg){0, NULL}, TRUE);
 
+            if (strncmp(uri, "about:", 6)) {
+                history_add(c, HISTORY_URL, uri, webkit_web_view_get_title(webview));
+            }
+
             break;
 
         case WEBKIT_LOAD_FINISHED:
@@ -1321,9 +1325,6 @@ static void on_webview_load_changed(WebKitWebView *webview,
             autocmd_run(c, AU_LOAD_FINISHED, uri, NULL);
 #endif
             c->state.progress = 100;
-            if (strncmp(uri, "about:", 6)) {
-                history_add(c, HISTORY_URL, uri, webkit_web_view_get_title(webview));
-            }
             break;
     }
 


### PR DESCRIPTION
When changing websites, a history item for the new website is only being
added as soon as loading it has been finished. This can lead to the
situation where you start on site A, navigate to site B, click on a link
C before the load finished, but land on page A again as soon as you
navigate back.

As the described behavior is really confusing in some cases and is
actively loosing intermediate data, we should add the history item a bit
earlier. To avoid adding calls which immediately redirect to somewhere
else, a good place to add it is the LoadCommitted hook. It fires after
the final redirect as soon as initial data from the site has been
loaded.