### PR TITLE
Remember element id when returning from external editor

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -171,7 +171,7 @@ VbResult input_open_editor(Client *c)
     EditorData *data = g_slice_new0(EditorData);
     data->file = file_path;
     data->c    = c;
-	 data->element_id   = g_strdup(id);
+    data->element_id   = g_strdup(id);
     g_child_watch_add(pid, (GChildWatchFunc)resume_editor, data);
 
     return RESULT_COMPLETE;
@@ -181,6 +181,7 @@ static void resume_editor(GPid pid, int status, EditorData *data)
 {
     char *text, *escaped;
     char *jscode;
+    char *jscode_enable;
 
     g_assert(pid);
     g_assert(data);
@@ -204,12 +205,11 @@ static void resume_editor(GPid pid, int status, EditorData *data)
         }
     }
 
-	 char *jscode_enable = g_strdup_printf(
-				 "document.getElementById(\"%s\").disabled=false;"
-				 "document.getElementById(\"%s\").focus()"
-			 , data->element_id, data->element_id);
-    ext_proxy_eval_script(data->c,
-			 jscode_enable, NULL);
+    jscode_enable = g_strdup_printf(
+                "document.getElementById(\"%s\").disabled=false;"
+                "document.getElementById(\"%s\").focus()"
+                 , data->element_id, data->element_id);
+    ext_proxy_eval_script(data->c, jscode_enable, NULL);
 
     g_unlink(data->file);
     g_free(data->file);

--- a/src/input.c
+++ b/src/input.c
@@ -187,6 +187,7 @@ static void resume_editor(GPid pid, int status, EditorData *data)
     g_assert(data);
     g_assert(data->c);
     g_assert(data->file);
+    g_assert(data->element_id);
 
     if (status == 0) {
         /* get the text the editor stored */
@@ -213,6 +214,7 @@ static void resume_editor(GPid pid, int status, EditorData *data)
 
     g_unlink(data->file);
     g_free(data->file);
+    g_free(data->element_id);
     g_slice_free(EditorData, data);
     g_spawn_close_pid(pid);
 }

--- a/src/input.c
+++ b/src/input.c
@@ -111,6 +111,7 @@ VbResult input_open_editor(Client *c)
 {
     static unsigned long element_map_next_key = 1;
     unsigned long element_map_key = 0;
+    char *element_id = NULL;
     char **argv, *file_path = NULL;
     const char *text = NULL, *id = NULL, *editor_command;
     int argc;
@@ -148,6 +149,8 @@ VbResult input_open_editor(Client *c)
         char *js_command = g_strdup_printf(JS_SET_EDITOR_MAP_ELEMENT, element_map_key);
         ext_proxy_eval_script(c, js_command, NULL);
         g_free(js_command);
+    } else {
+        element_id   = g_strdup(id);
     }
 
     /* create a temp file to pass text to and from editor */
@@ -185,10 +188,7 @@ VbResult input_open_editor(Client *c)
     EditorData *data = g_slice_new0(EditorData);
     data->file = file_path;
     data->c    = c;
-    if( id && strlen(id) > 0 )
-        data->element_id   = g_strdup(id);
-    else
-        data->element_id = NULL;
+    data->element_id = element_id;
     data->element_map_key = element_map_key;
     
     g_child_watch_add(pid, (GChildWatchFunc)resume_editor, data);

--- a/src/scripts/focus_editor_map_element.js
+++ b/src/scripts/focus_editor_map_element.js
@@ -1,0 +1,2 @@
+vimb_editor_map.get("%lu").disabled=false;
+vimb_editor_map.get("%lu").focus()

--- a/src/scripts/focus_element_by_id.js
+++ b/src/scripts/focus_element_by_id.js
@@ -1,0 +1,2 @@
+document.getElementById("%s").disabled=false;
+document.getElementById("%s").focus()

--- a/src/scripts/set_editor_map_element.js
+++ b/src/scripts/set_editor_map_element.js
@@ -1,0 +1,4 @@
+if ( typeof(vimb_editor_map) !== 'object' ) { 
+	var vimb_editor_map = new Map; 
+}
+vimb_editor_map.set("%lu", vimb_input_mode_element)


### PR DESCRIPTION
Problem I'm trying to fix:
When editing an input via external editor and returning to vimb to look up some information, like a previous forum post, it sometimes got stuck on a different input element, writing the editor text to that elements value even if it did not posses one(like a select list)
This also meant the original element was not enabled again so it was not possible to return without using the web inspector.

Technical change:
Instead of relying on `vimb_input_mode_element` to still point to the correct element when the editor returns it passes the element id to the child watcher in the data.

It actually has a few more benefits than what I was trying to achieve. It is even possible to browse to different pages with the editor open as long as you return to the page with the original input element before closing the editor(and the id has not changed for some reason).
Also you can open more than one editor window at the same time for different input elements, althougth I can't imagine a case where that'd be useful.
