### PR TITLE
Clarify :set usage in man page

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -621,7 +621,9 @@ it.
 .BI ":se[t] " var = value
 Set configuration values named by \fIvar\fP.
 To set boolean variable you should use 'on', 'off' or 'true' and 'false'.
-Colors are given as hexadecimal value like '#f57700'.
+Colors are given as hexadecimal value like '#f57700'. Spaces or more equals
+signs in \fIvalue\fP just work without quotes: for example,
+":set sans-serif-font=Some Sans Font".
 .TP
 .BI ":se[t] " var += value
 Add the \fIvalue\fP to a number option, or append the \fIvalue\fP to a string
@@ -965,7 +967,7 @@ The search completion allows a filtered list of already done searches.
 This completion starts by `/` or `?` in inputbox and performs a prefix
 comparison for further typed chars.
 .SH SETTINGS
-All settings listed below can be set with the `:set' command.
+All settings listed below can be set with the `:set' command. See \fBSettings\fP under \fBCOMMAND MODE\fP for syntax.
 .TP
 .B accelerated-2d-canvas (bool)
 Enable or disable accelerated 2D canvas.


### PR DESCRIPTION
It takes a while to work out from the man page how to use `:set`. Hopefully this clears up some things.