### PR TITLE
Allow user to hide and show the titlebar on demand. Fixes #439.

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1215,6 +1215,9 @@ Number of pixel vimb scrolls if 'j' or 'k' is used.
 .B serif-font (string)
 The font family used as the default for content using serif font.
 .TP
+.B show-titlebar (bool)
+Determines whether the titlebar is shown (on systems that provide window decoration). Defaults to true.
+.TP
 .B site-specific-quirks (bool)
 Enables the site-specific compatibility workarounds.
 .TP

--- a/src/setting.c
+++ b/src/setting.c
@@ -66,6 +66,7 @@ static int tls_policy(Client *c, const char *name, DataType type, void *value, v
 static int webkit(Client *c, const char *name, DataType type, void *value, void *data);
 static int webkit_spell_checking(Client *c, const char *name, DataType type, void *value, void *data);
 static int webkit_spell_checking_language(Client *c, const char *name, DataType type, void *value, void *data);
+static int window_decorate(Client *c, const char *name, DataType type, void *value, void *data);
 
 extern struct Vimb vb;
 
@@ -145,6 +146,7 @@ void setting_init(Client *c)
     setting_add(c, "timeoutlen", TYPE_INTEGER, &i, internal, 0, &c->map.timeoutlen);
     setting_add(c, "input-autohide", TYPE_BOOLEAN, &off, input_autohide, 0, &c->config.input_autohide);
     setting_add(c, "fullscreen", TYPE_BOOLEAN, &off, fullscreen, 0, NULL);
+    setting_add(c, "show-titlebar", TYPE_BOOLEAN, &on, window_decorate, 0, NULL);
     i = 100;
     setting_add(c, "default-zoom", TYPE_INTEGER, &i, default_zoom, 0, NULL);
     setting_add(c, "download-path", TYPE_CHAR, &"~/", NULL, 0, NULL);
@@ -534,6 +536,17 @@ static int fullscreen(Client *c, const char *name, DataType type, void *value, v
     }
 
     return CMD_SUCCESS;
+}
+
+/* This needs to be called before the window is shown for the best chance of
+ * success, but it may be called at any time.
+ * Currently the setting file is read after the window has been shown, which
+ * might mean the titlebar isn't hidden on certain environments. */
+static int window_decorate(Client *c, const char *name, DataType type, void *value, void *data)
+{
+  gtk_window_set_decorated(GTK_WINDOW(c->window), *(gboolean*)value);
+
+  return CMD_SUCCESS;
 }
 
 #if WEBKIT_CHECK_VERSION (2, 16, 0)


### PR DESCRIPTION
This works for me, and since my system is pretty mainstream it should work for lots of others too. As noted in the code, it doesn't provide a way for the user to hide the titlebar if they're using a system where you have to call `gtk_window_set_decorated` before showing the window, since the config file is read too late. (Obviously the call to `ex_run_file` in `main.c` could just be moved up a few lines but since that might have broken something else I haven't done it.)
I don't know how common it is for a window manager to make this not work. Gtk has been around for a while and this might well be a caveat that's only applicable to obscure systems from 10 years ago.