### PR TITLE
Detect localhost and IPv6 as valid URLs. Fixes #478.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -382,8 +382,11 @@ gboolean vb_load_uri(Client *c, const Arg *arg)
         rp  = realpath(path, NULL);
         uri = g_strconcat("file://", rp, NULL);
         free(rp);
-    } else if (strchr(path, ' ') || !strchr(path, '.')) {
-        /* use a shortcut if path contains spaces or no dot */
+    } else if (strchr(path, ' ') || !(strchr(path, '.') ||
+          (strchr(path, '[') && strchr(path, ':') && strchr(path, ']')) ||
+          strstr(path, "localhost"))) {
+        /* use a shortcut if path contains spaces or doesn't contain typical
+         * characters ('.', [:] for IPv6 addresses, 'localhost') */
         uri = shortcut_get_uri(c->config.shortcuts, path);
     }
 


### PR DESCRIPTION
The following commands now work:
```
:open [::1]
:open [::1]:631
:open localhost
:open localhost:631
```
This still (correctly) goes to a shortcut:
```
:open [::1:631
:open ::1]:631
```
As was already the case, some malformed URLs don't get sent to a shortcut, and end up at `about:blank`.
```
:open 127.0.0.1:foobar
:open ::1[]:631
```