### PR TITLE
Fix missing string.h include

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -19,6 +19,7 @@
 
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <string.h>
 
 #include "ascii.h"
 #include "config.h"


### PR DESCRIPTION
It is causing an incompatible implicit declaration warning.