### PR TITLE
Makefile: add dependency on scripts.h to input.o

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,8 @@ vimb.so: $(OBJ)
 
 $(OBJ): config.h ../config.mk
 
+input.o: scripts/scripts.h
+
 normal.o: scripts/scripts.h
 
 setting.o: scripts/scripts.h


### PR DESCRIPTION
While "input.c" includes "scripts/scripts.h", which is generated
dynamically by the build system, the Makefile does not state a
dependency of "input.c" on "scripts/scripts.h". Add the dependency to
fix broken builds.