### PR TITLE
WIP: Convert JS to C

### DIFF
--- a/src/ext-proxy.c
+++ b/src/ext-proxy.c
@@ -224,6 +224,16 @@ void ext_proxy_set_header(Client *c, const char *headers)
     dbus_call(c, "SetHeaderSetting", g_variant_new("(s)", headers), NULL);
 }
 
+void ext_proxy_lock_input(Client *c, const char *element_id)
+{
+    dbus_call(c, "LockInput", g_variant_new("(ts)", c->page_id, element_id), NULL);
+}
+
+void ext_proxy_unlock_input(Client *c, const char *element_id)
+{
+    dbus_call(c, "UnlockInput", g_variant_new("(ts)", c->page_id, element_id), NULL);
+}
+
 /**
  * Call a dbus method.
  */

--- a/src/ext-proxy.h
+++ b/src/ext-proxy.h
@@ -27,5 +27,7 @@ void ext_proxy_eval_script(Client *c, char *js, GAsyncReadyCallback callback);
 GVariant *ext_proxy_eval_script_sync(Client *c, char *js);
 void ext_proxy_focus_input(Client *c);
 void ext_proxy_set_header(Client *c, const char *headers);
+void ext_proxy_lock_input(Client *c, const char *element_id);
+void ext_proxy_unlock_input(Client *c, const char *element_id);
 
 #endif /* end of include guard: _EXT_PROXY_H */

--- a/src/scripts/focus_element_by_id.js
+++ b/src/scripts/focus_element_by_id.js
@@ -1,2 +1,0 @@
-document.getElementById("%s").disabled=false;
-document.getElementById("%s").focus();

--- a/src/webextension/ext-dom.c
+++ b/src/webextension/ext-dom.c
@@ -33,11 +33,11 @@ gboolean ext_dom_is_editable(WebKitDOMElement *element)
 {
     char *type;
     gboolean result = FALSE;
-    
+
     if (!element) {
         return FALSE;
     }
-    
+
     /* element is editable if it's a text area or input with no type, text or
      * password */
     if (webkit_dom_html_element_get_is_content_editable(WEBKIT_DOM_HTML_ELEMENT(element))
@@ -170,6 +170,27 @@ char *ext_dom_editable_get_value(WebKitDOMElement *element)
     return value;
 }
 
+void ext_dom_lock_input(WebKitDOMDocument *parent, char *element_id)
+{
+    WebKitDOMElement *elem;
+
+    elem = webkit_dom_document_get_element_by_id(parent, element_id);
+    if (elem != NULL) {
+        webkit_dom_element_set_attribute(elem, "disabled", "true", NULL);
+    }
+}
+
+void ext_dom_unlock_input(WebKitDOMDocument *parent, char *element_id)
+{
+    WebKitDOMElement *elem;
+
+    elem = webkit_dom_document_get_element_by_id(parent, element_id);
+    if (elem != NULL) {
+        webkit_dom_element_remove_attribute(elem, "disabled");
+        webkit_dom_element_focus(elem);
+    }
+}
+
 /**
  * Indicates if the give nelement is visible.
  */
@@ -177,3 +198,4 @@ static gboolean is_element_visible(WebKitDOMHTMLElement *element)
 {
     return TRUE;
 }
+

--- a/src/webextension/ext-dom.h
+++ b/src/webextension/ext-dom.h
@@ -26,5 +26,7 @@
 gboolean ext_dom_is_editable(WebKitDOMElement *element);
 gboolean ext_dom_focus_input(WebKitDOMDocument *doc);
 char *ext_dom_editable_get_value(WebKitDOMElement *element);
+void ext_dom_lock_input(WebKitDOMDocument *parent, char *element_id);
+void ext_dom_unlock_input(WebKitDOMDocument *parent, char *element_id);
 
 #endif /* end of include guard: _EXT-DOM_H */

--- a/src/webextension/ext-main.c
+++ b/src/webextension/ext-main.c
@@ -84,6 +84,14 @@ static const char introspection_xml[] =
     "  <method name='SetHeaderSetting'>"
     "   <arg type='s' name='headers' direction='in'/>"
     "  </method>"
+    "  <method name='LockInput'>"
+    "   <arg type='t' name='page_id' direction='in'/>"
+    "   <arg type='s' name='elemend_id' direction='in'/>"
+    "  </method>"
+    "  <method name='UnlockInput'>"
+    "   <arg type='t' name='page_id' direction='in'/>"
+    "   <arg type='s' name='elemend_id' direction='in'/>"
+    "  </method>"
     " </interface>"
     "</node>";
 
@@ -418,6 +426,22 @@ static void dbus_handle_method_call(GDBusConnection *conn, const char *sender,
             ext.headers = NULL;
         }
         ext.headers = soup_header_parse_param_list(value);
+        g_dbus_method_invocation_return_value(invocation, NULL);
+    } else if (!g_strcmp0(method, "LockInput")) {
+        g_variant_get(parameters, "(ts)", &pageid, &value);
+        page = get_web_page_or_return_dbus_error(invocation, WEBKIT_WEB_EXTENSION(extension), pageid);
+        if (!page) {
+            return;
+        }
+        ext_dom_lock_input(webkit_web_page_get_dom_document(page), value);
+        g_dbus_method_invocation_return_value(invocation, NULL);
+    } else if (!g_strcmp0(method, "UnlockInput")) {
+        g_variant_get(parameters, "(ts)", &pageid, &value);
+        page = get_web_page_or_return_dbus_error(invocation, WEBKIT_WEB_EXTENSION(extension), pageid);
+        if (!page) {
+            return;
+        }
+        ext_dom_unlock_input(webkit_web_page_get_dom_document(page), value);
         g_dbus_method_invocation_return_value(invocation, NULL);
     }
 }


### PR DESCRIPTION
This is a proposal accompanied by a small POC: How about getting rid of the JS code and converting all to C?

I feel like the current Main -> dbus -> JS system make our code more complicated than it should. `hint.js` is a bit too complicated. I'm not sure yet, but I have the feeling that re-implementing all JS code in C would result in a simpler and more elegant code overall.

Of course, right now the dbus interfacing code is a bit messy, but I'm sure we could re-organize it into something a bit more elegant.

@fanglingsu, what do you think?