### PR TITLE
Fix a copypasto regarding user-scripts option

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1292,7 +1292,7 @@ to complete.
 The user-agent string used by WebKit.
 .TP
 .B user-scripts (bool)
-Indicates if user style sheet file $XDG_CONFIG_HOME/vimb/style.css is sourced.
+If 'on' the user scripts are injected into every page.
 .TP
 .B webaudio (bool)
 Enable or disable support for WebAudio on pages.


### PR DESCRIPTION
The description of user-scripts option accidentally referred to
userstyles, probably due a copypasto of the option description in
the man page (or, in other words, enabling/disabling user-scripts
option really enable/disable running user scripts via user.js
file!).