### PR TITLE
Add support for marks, based on vimb-2.12.

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -189,6 +189,18 @@ Scroll page \fIN\fP steps down.
 .TP
 .BI [ N ]k
 Scroll page \fIN\fP steps up.
+.TP
+.BI m{ a-z }
+Set a page mark {\fIa-z\fP} at the current position on the page.
+Such set marks are only available on the current page;
+if the page is left, all marks will be removed.
+.TP
+.BI '{ a-z }
+Jump to the mark {\fIa-z\fP} on the current page.
+.TP
+.B ''
+Jumps to the position before the latest jump, or where the last "m'" command
+was given.
 .SS Hinting
 Hinting in Vimb is how you accomplish the tasks that you would do with the
 mouse in common mouse-driven browsers: open a URI, yank a URI, save a page and

--- a/src/ext-proxy.c
+++ b/src/ext-proxy.c
@@ -180,16 +180,17 @@ static void on_vertical_scroll(GDBusConnection *connection,
         const char *interface_name, const char *signal_name,
         GVariant *parameters, gpointer data)
 {
-    glong max;
+    glong max, top;
     guint percent;
     guint64 pageid;
     Client *c;
 
-    g_variant_get(parameters, "(ttq)", &pageid, &max, &percent);
+    g_variant_get(parameters, "(ttqt)", &pageid, &max, &percent, &top);
     c = vb_get_client_for_page_id(pageid);
     if (c) {
         c->state.scroll_max     = max;
         c->state.scroll_percent = percent;
+        c->state.scroll_top     = top;
     }
 
     vb_statusbar_update(c);

--- a/src/main.h
+++ b/src/main.h
@@ -154,12 +154,13 @@ struct State {
 
 #define PROMPT_SIZE 4
     char                prompt[PROMPT_SIZE];/* current prompt ':', 'g;t', '/' including nul */
-    gdouble             marks[MARK_SIZE];   /* holds marks set to page with 'm{markchar}' */
+    glong               marks[MARK_SIZE];   /* holds marks set to page with 'm{markchar}' */
     guint               input_timer;
     MessageType         input_type;
     StatusType          status_type;
     glong               scroll_max;         /* Maxmimum scrollable height of the document. */
-    guint               scroll_percent;     /* Current position of the viewport in document. */
+    guint               scroll_percent;     /* Current position of the viewport in document (percent). */
+    glong               scroll_top;         /* Current position of the viewport in document (pixel). */
     char                *title;             /* Window title of the client. */
 
     char                *reg[REG_SIZE];     /* holds the yank buffers */

--- a/src/webextension/ext-main.c
+++ b/src/webextension/ext-main.c
@@ -80,6 +80,7 @@ static const char introspection_xml[] =
     "   <arg type='t' name='page_id' direction='out'/>"
     "   <arg type='t' name='max' direction='out'/>"
     "   <arg type='q' name='percent' direction='out'/>"
+    "   <arg type='t' name='top' direction='out'/>"
     "  </signal>"
     "  <method name='SetHeaderSetting'>"
     "   <arg type='s' name='headers' direction='in'/>"
@@ -249,7 +250,7 @@ static void on_document_scroll(WebKitDOMEventTarget *target, WebKitDOMEvent *eve
 
     if (doc) {
         WebKitDOMElement *body, *de;
-        glong max = 0, scrollTop, scrollHeight, clientHeight;
+        glong max = 0, top = 0, scrollTop, scrollHeight, clientHeight;
         guint percent = 0;
 
         de = webkit_dom_document_get_document_element(doc);
@@ -276,10 +277,11 @@ static void on_document_scroll(WebKitDOMEventTarget *target, WebKitDOMEvent *eve
         max = scrollHeight - clientHeight;
         if (max > 0) {
             percent = (guint)(0.5 + (scrollTop * 100 / max));
+            top = scrollTop;
         }
 
-        dbus_emit_signal("VerticalScroll", g_variant_new("(ttq)",
-                webkit_web_page_get_id(page), max, percent));
+        dbus_emit_signal("VerticalScroll", g_variant_new("(ttqt)",
+                webkit_web_page_get_id(page), max, percent, top));
     }
 }
 


### PR DESCRIPTION
These two commits, one for vimb source code, the other to update
vimb(1) man page restore the support for page marks as present in
vimb-2.12 (and also most of the code is based on it, in particular
normal_map() implementation!).

This should also partly address issue #355.