### PR TITLE
Use webkit2-gtk-web-extension-4.0 for EXT{C,LD}FLAGS in config.mk

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -34,9 +34,9 @@ CPPFLAGS += -DGDK_DISABLE_DEPRECATED
 
 # flags used to build webextension
 EXTTARGET   = webext_main.so
-EXTCFLAGS   = ${CFLAGS} $(shell pkg-config --cflags webkit2gtk-4.0)
+EXTCFLAGS   = ${CFLAGS} $(shell pkg-config --cflags webkit2gtk-web-extension-4.0)
 EXTCPPFLAGS = $(CPPFLAGS)
-EXTLDFLAGS  = $(shell pkg-config --libs webkit2gtk-4.0) -shared
+EXTLDFLAGS  = $(shell pkg-config --libs webkit2gtk-web-extension-4.0) -shared
 
 # flags used for the main application
 CFLAGS     += $(shell pkg-config --cflags $(LIBS))


### PR DESCRIPTION
webkitgtk provides a webkit2gtk-web-extension-4.0 .pc file for
webkitgtk web extensions, use it for the web extension.

Please note that ATM both `--cflags' and `--libs' webkit2gtk-4.0
and webkit2gtk-web-extension-4.0 returns the same values but if
they will diverge in the future the web extension will then use
the right `.pc'.