### PR TITLE
Document a subtlety of util_parse_expansion() and adjust test_expand_tilde_user() accordingly

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -678,6 +678,10 @@ double util_js_result_as_number(WebKitJavascriptResult *result)
  * not expanded char. If no expansion pattern was found, the first char is
  * appended to given GString.
  *
+ * Please note that for a single ~, g_get_home_dir() is used and if a valid
+ * HOME environment variable is set it is preferred than passwd file.
+ * However, for ~user expansion the passwd file is always used.
+ *
  * @input:     String pointer with the content to be parsed.
  * @str:       GString that will be filled with expanded content.
  * @flags      Flags that determine which expansion are processed.

--- a/tests/test-util.c
+++ b/tests/test-util.c
@@ -17,6 +17,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
+#include <pwd.h>
 #include <gtk/gtk.h>
 #include <src/util.h>
 
@@ -88,9 +89,15 @@ static void test_expand_tilde_home(void)
 static void test_expand_tilde_user(void)
 {
     State state = {0};
-    const char *home = g_get_home_dir();
     const char *user = g_get_user_name();
+    const char *home;
     char *in, *out;
+    struct passwd *pwd;
+
+    /* initialize home */
+    pwd = getpwnam(user);
+    g_assert_nonnull(pwd);
+    home = pwd->pw_dir;
 
     /* don't expand within words */
     in = g_strdup_printf("foo~%s/bar", user);


### PR DESCRIPTION
Single ~ uses g_get_home_dir() that honor HOME environment variable.
However, ~user always consult the passwd file.

Adjust test_expand_tilde_user() to reflect this behaviour and always use
getpwnam() there (instead of g_get_home_dir() that can lead to incorrect
results if HOME is set).

This was noticed when running the `test' target on pkgsrc, where
an HOME directory is set to a fake directory.