### PR TITLE
Fix out-of-bounds buffer access in parse_command

### DIFF
--- a/src/ex.c
+++ b/src/ex.c
@@ -657,7 +657,7 @@ static gboolean parse_command_name(Client *c, const char **input, ExArg *arg)
         /* read until next whitespace or end of input to get command name for
          * error message - vim uses the whole rest of the input string - but
          * the first word seems to bee enough for the error message */
-        for (; len < LENGTH(cmd) && *input && !VB_IS_SPACE(**input); (*input)++) {
+        for (; len < (LENGTH(cmd) - 1) && *input && !VB_IS_SPACE(**input); (*input)++) {
             cmd[len++] = **input;
         }
         cmd[len] = '\0';


### PR DESCRIPTION
Since the cmd buffer needs to be null terminated we need to reserve
space for the null byte in the buffer.

Without this change an out-of-bounds buffer access is performed if the
first word is longer than 19 chars.

Fixes #529