### PR TITLE
Disallow window open

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1234,6 +1234,11 @@ not allow a page to store data in the windows sessionStorage.
 .B plugins (bool)
 Determines whether or not plugins on the page are enabled.
 .TP
+.B prevent-newwindow (bool)
+Whether to open links, that would normally open in a new window, in the
+current window.
+This option does not affect links fired by hinting.
+.TP
 .B sans-serif-font (string)
 The font family used as the default for content using sans-serif font.
 .TP

--- a/src/main.h
+++ b/src/main.h
@@ -235,6 +235,7 @@ struct Client {
         guint                   scrollstep;
         gboolean                input_autohide;
         gboolean                incsearch;
+        gboolean                prevent_newwindow;
         guint                   default_zoom;   /* default zoom level in percent */
         Shortcut                *shortcuts;
     } config;

--- a/src/setting.c
+++ b/src/setting.c
@@ -114,6 +114,7 @@ void setting_init(Client *c)
     setting_add(c, "monospace-font-size", TYPE_INTEGER, &i, webkit, 0, "default-monospace-font-size");
     setting_add(c, "offline-cache", TYPE_BOOLEAN, &on, webkit, 0, "enable-offline-web-application-cache");
     setting_add(c, "plugins", TYPE_BOOLEAN, &on, webkit, 0, "enable-plugins");
+    setting_add(c, "prevent-newwindow", TYPE_BOOLEAN, &off, internal, 0, &c->config.prevent_newwindow);
     setting_add(c, "print-backgrounds", TYPE_BOOLEAN, &on, webkit, 0, "print-backgrounds");
     setting_add(c, "private-browsing", TYPE_BOOLEAN, &off, webkit, 0, "enable-private-browsing");
     setting_add(c, "sans-serif-font", TYPE_CHAR, &"sans-serif", webkit, 0, "sans-serif-font-family");

--- a/tests/manual/dummy.html
+++ b/tests/manual/dummy.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Dummy Page</title>
+</head>
+<body>
+Dummy Page
+</body>
+</html>
+
+

--- a/tests/manual/window-open.html
+++ b/tests/manual/window-open.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<title>Window open</title>
+</head>
+<body>
+    <a href="./dummy.html" target="">target=""</a><br/>
+    <a href="./dummy.html" target="_new">target="_new"</a><br/>
+    <a href="./dummy.html" target="_blank">target="_blank"</a><br/>
+    <a href="./dummy.html" target="foo">target iframe</a><br/>
+    <a href="javascript:window.open('./dummy.html', 'winname')">javascript:window-open</a><br/>
+    <a href="#" onclick="window.open('./dummy.html', 'winname')">onclick window-open</a><br/>
+    <iframe src="" name="foo"></iframe>
+</body>
+</html>
+

--- a/tests/manual/window-open.html
+++ b/tests/manual/window-open.html
@@ -3,13 +3,19 @@
 <title>Window open</title>
 </head>
 <body>
-    <a href="./dummy.html" target="">target=""</a><br/>
-    <a href="./dummy.html" target="_new">target="_new"</a><br/>
-    <a href="./dummy.html" target="_blank">target="_blank"</a><br/>
-    <a href="./dummy.html" target="foo">target iframe</a><br/>
-    <a href="javascript:window.open('./dummy.html', 'winname')">javascript:window-open</a><br/>
-    <a href="#" onclick="window.open('./dummy.html', 'winname')">onclick window-open</a><br/>
-    <iframe src="" name="foo"></iframe>
+    <p>
+        Enable <code>set prevent-newwindow=on</code><br/>
+        Following link should be opened into current window.<br/><br/>
+        <a href="./dummy.html" target="_new">target="_new"</a><br/>
+        <a href="./dummy.html" target="_blank">target="_blank"</a><br/>
+        <a href="javascript:window.open('./dummy.html', 'winname')">javascript:window-open</a><br/>
+        <a href="#" onclick="window.open('./dummy.html', 'winname')">onclick window-open</a><br/>
+    </p>
+    <p>
+        This <a href="./dummy.html" target="foo">target iframe link</a> should
+        load into the iframe.<br/>
+        <iframe src="" name="foo"></iframe>
+    </p>
 </body>
 </html>
 


### PR DESCRIPTION
Added the new option 'prevent-newwindow' to prevent opening links into new window. This does not affect the behaviour of the links fired by hinting.
Closes #544