### PR TITLE
Fix NULL ret of util_sanitize_uri

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -837,6 +837,9 @@ char *util_sanitize_uri(const char *uri_str)
 #else
     for_display = g_strdup(uri_str);
 #endif
+    if (!for_display) {
+	    return NULL;
+    }
 
     /* Sanitize the uri only in case there is a @ which might be the indicator
      * for credentials used in uri. */


### PR DESCRIPTION
* in `util_sanitize_uri`,  `webkit_uri_for_display` can return NULL, so failing early
* `util_sanitize_uri` can return NULL, so  adding check of return value before using it