### PR TITLE
autocmd: implement new LoadStarting event

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -709,6 +709,10 @@ No white space can be used in this list.
 .PD 0
 Events:
 .TP
+.B LoadStarting
+Fired before a new page is going to be opened.
+No data has been sent or received yet, the load may still fail for transport issues.
+.TP
 .B LoadStarted
 Fired if a new page is going to be opened.
 No data has been received yet, the load may still fail for transport issues.

--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -44,15 +44,16 @@ static struct {
     const char *name;
     guint      bits;
 } events[] = {
-    {"*",                0x00ff},
-    {"LoadStarted",      0x0001},
-    {"LoadCommitted",    0x0002},
-    /*{"LoadFirstLayout",  0x0004},*/
-    {"LoadFinished",     0x0008},
-    /*{"LoadFailed",       0x0010},*/
-    {"DownloadStarted",  0x0020},
-    {"DownloadFinished", 0x0040},
-    {"DownloadFailed",   0x0080},
+    {"*",                0x01ff},
+    {"LoadStarting",     0x0001},
+    {"LoadStarted",      0x0002},
+    {"LoadCommitted",    0x0004},
+    /*{"LoadFirstLayout",  0x0008},*/
+    {"LoadFinished",     0x0010},
+    /*{"LoadFailed",       0x0020},*/
+    {"DownloadStarted",  0x0040},
+    {"DownloadFinished", 0x0080},
+    {"DownloadFailed",   0x0100},
 };
 
 static GSList *get_group(Client *c, const char *name);

--- a/src/autocmd.h
+++ b/src/autocmd.h
@@ -28,6 +28,7 @@
 /* this values correspond to indices in events[] array in autocmd.c */
 typedef enum {
     AU_ALL,
+    AU_LOAD_STARTING,
     AU_LOAD_STARTED,
     AU_LOAD_COMMITTED,
     /*AU_LOAD_FIRST_LAYOUT,*/

--- a/src/main.c
+++ b/src/main.c
@@ -1374,6 +1374,10 @@ static void decide_navigation_action(Client *c, WebKitPolicyDecision *dec)
         webkit_policy_decision_ignore(dec);
         spawn_new_instance(uri);
     } else {
+#ifdef FEATURE_AUTOCMD
+        if (strcmp(uri, "about:blank"))
+            autocmd_run(c, AU_LOAD_STARTING, uri, NULL);
+#endif
         webkit_policy_decision_use(dec);
     }
 }


### PR DESCRIPTION
The first autocommand event that is being triggered when loading a
website is the "LoadStarted" event. LoadStarted gets triggered when the
web view has started loading of the page, notably after the initial
request has been sent. Thus, this event comes too late to change
settings that would modify the initial request, like e.g. the user
agent.

Implement a new event LoadStarting that triggers immediately before
performing the initial load and thus before LoadStarted. As WebKit does
not provide any signal for this, we have to manually trigger this event
when executing any load or navigation actions.

This change enables one to modify configuration like the user agent for
certain websites, which was not possible with "LoadStarted".