### PR TITLE
Hinting over an element with no url or source is not an error

### DIFF
--- a/src/hints.c
+++ b/src/hints.c
@@ -328,8 +328,6 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
             } else {
                 vb_statusbar_show_hover_url(c, LINK_TYPE_LINK, value + 7);
             }
-        } else {
-            goto error;
         }
     } else if (!strncmp(value, "DONE:", 5)) {
         fire_timeout(c, FALSE);


### PR DESCRIPTION
focusHint returning "OVER:A:" because the hint element did not have
a src or href was treated as an error, and led to the hint keystroke
also being passed down to the page.