### PR TITLE
Fix crash in normal_focus_last_active

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -450,7 +450,7 @@ static VbResult normal_focus_last_active(Client *c, const NormalCmdInfo *info)
     gboolean focused;
 
     variant = ext_proxy_eval_script_sync(c, "vimb_input_mode_element.focus();");
-    g_variant_get(variant, "(bs)", &focused);
+    g_variant_get(variant, "(bs)", &focused, NULL);
     if (!focused) {
         ext_proxy_focus_input(c);
     }


### PR DESCRIPTION
g_variant_get was missing a parameter for the string element of
the variant tuple, pass NULL there as we dont care about that value.