### PR TITLE
Expanded dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ the project page of [Vimb][].
 
 - gtk+-3.0
 - webkit2gtk-4.0 >= 2.20.x
+- gstreamer
+- gst-libav
+- gst-plugins-good
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ the project page of [Vimb][].
 
 - gtk+-3.0
 - webkit2gtk-4.0 >= 2.20.x
-- gstreamer
-- gst-libav
-- gst-plugins-good
+- gst-libav (for media decoding)
+- gst-plugins-good (for nonfree media decoding)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ the project page of [Vimb][].
 
 - gtk+-3.0
 - webkit2gtk-4.0 >= 2.20.x
-- gst-libav (for media decoding)
-- gst-plugins-good (for nonfree media decoding)
+- gst-libav (optional, for media decoding)
+- gst-plugins-good (optional, for nonfree media decoding among other things)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the project page of [Vimb][].
 
 - gtk+-3.0
 - webkit2gtk-4.0 >= 2.20.x
-- gst-libav (optional, for media decoding), gst-plugins-good (optional, for nonfree media decoding among other things)
+- gst-libav, gst-plugins-good (optional, for media decoding among other things)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ the project page of [Vimb][].
 
 - gtk+-3.0
 - webkit2gtk-4.0 >= 2.20.x
-- gst-libav (optional, for media decoding)
-- gst-plugins-good (optional, for nonfree media decoding among other things)
+- gst-libav (optional, for media decoding), gst-plugins-good (optional, for nonfree media decoding among other things)
 
 ## Install
 


### PR DESCRIPTION
These additions to the README clarify which packages need to be installed to get media to work in vimb and thus solves #647 and also #606 