### PR TITLE
Use guint64 instead of glong.

### DIFF
--- a/src/ext-proxy.c
+++ b/src/ext-proxy.c
@@ -180,7 +180,7 @@ static void on_vertical_scroll(GDBusConnection *connection,
         const char *interface_name, const char *signal_name,
         GVariant *parameters, gpointer data)
 {
-    glong max, top;
+    guint64 max, top;
     guint percent;
     guint64 pageid;
     Client *c;

--- a/src/main.h
+++ b/src/main.h
@@ -169,13 +169,13 @@ struct State {
 
 #define PROMPT_SIZE 4
     char                prompt[PROMPT_SIZE];/* current prompt ':', 'g;t', '/' including nul */
-    glong               marks[MARK_SIZE];   /* holds marks set to page with 'm{markchar}' */
+    guint64             marks[MARK_SIZE];   /* holds marks set to page with 'm{markchar}' */
     guint               input_timer;
     MessageType         input_type;
     StatusType          status_type;
-    glong               scroll_max;         /* Maxmimum scrollable height of the document. */
+    guint64             scroll_max;         /* Maxmimum scrollable height of the document. */
     guint               scroll_percent;     /* Current position of the viewport in document (percent). */
-    glong               scroll_top;         /* Current position of the viewport in document (pixel). */
+    guint64             scroll_top;         /* Current position of the viewport in document (pixel). */
     char                *title;             /* Window title of the client. */
 
     char                *reg[REG_SIZE];     /* holds the yank buffers */

--- a/src/normal.c
+++ b/src/normal.c
@@ -547,7 +547,7 @@ static VbResult normal_input_open(Client *c, const NormalCmdInfo *info)
 
 static VbResult normal_mark(Client *c, const NormalCmdInfo *info)
 {
-    glong current;
+    guint64 current;
     char *js, *mark;
     int idx;
 
@@ -570,7 +570,7 @@ static VbResult normal_mark(Client *c, const NormalCmdInfo *info)
         current = c->state.scroll_top;
 
         /* jump to the location */
-        js = g_strdup_printf("window.scroll(window.screenLeft,%ld);", c->state.marks[idx]);
+        js = g_strdup_printf("window.scroll(window.screenLeft,%" G_GUINT64_FORMAT ");", c->state.marks[idx]);
         ext_proxy_eval_script(c, js, NULL);
         g_free(js);
 

--- a/src/webextension/ext-main.c
+++ b/src/webextension/ext-main.c
@@ -250,7 +250,7 @@ static void on_document_scroll(WebKitDOMEventTarget *target, WebKitDOMEvent *eve
 
     if (doc) {
         WebKitDOMElement *body, *de;
-        glong max = 0, top = 0, scrollTop, scrollHeight, clientHeight;
+        guint64 max = 0, top = 0, scrollTop, scrollHeight, clientHeight;
         guint percent = 0;
 
         de = webkit_dom_document_get_document_element(doc);


### PR DESCRIPTION
The glong type is not always guaranteed to be large enough, e.g., on 32
bit platform. One result is that the scroll percentage is a weird
number. Using explict 64 bit types fixes this.