### PR TITLE
Add setting for toggling javascript markup option

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1538,6 +1538,12 @@ This fills the inputbox with the prefilled download command and replaces
 Whether to enable the XSS auditor.
 This feature filters some kinds of reflective XSS attacks on vulnerable web
 sites.
+.PD
+.RE
+.TP
+.B javascript-enable-markup (bool)
+Whether JavaScript markup is enabled.
+Disabling can help with some older systems (ppc, ppc64, etc.) that don't have complete JavaScript support to run webpages without crashing.
 .
 .
 .SH FILES

--- a/src/setting.c
+++ b/src/setting.c
@@ -109,6 +109,7 @@ void setting_init(Client *c)
     setting_add(c, "images", TYPE_BOOLEAN, &on, webkit, 0, "auto-load-images");
     setting_add(c, "javascript-can-access-clipboard", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-access-clipboard");
     setting_add(c, "javascript-can-open-windows-automatically", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-open-windows-automatically");
+    setting_add(c, "javascript-enable-markup", TYPE_BOOLEAN, &on, webkit, 0, "enable-javascript-markup");
     setting_add(c, "media-playback-allows-inline", TYPE_BOOLEAN, &on, webkit, 0, "media-playback-allows-inline");
     setting_add(c, "media-playback-requires-user-gesture", TYPE_BOOLEAN, &off, webkit, 0, "media-playback-requires-user-gesture");
     setting_add(c, "media-stream", TYPE_BOOLEAN, &off, webkit, 0, "enable-media-stream");

--- a/src/setting.c
+++ b/src/setting.c
@@ -109,7 +109,9 @@ void setting_init(Client *c)
     setting_add(c, "images", TYPE_BOOLEAN, &on, webkit, 0, "auto-load-images");
     setting_add(c, "javascript-can-access-clipboard", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-access-clipboard");
     setting_add(c, "javascript-can-open-windows-automatically", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-open-windows-automatically");
+#if WEBKIT_CHECK_VERSION(2, 24, 0)
     setting_add(c, "javascript-enable-markup", TYPE_BOOLEAN, &on, webkit, 0, "enable-javascript-markup");
+#endif
     setting_add(c, "media-playback-allows-inline", TYPE_BOOLEAN, &on, webkit, 0, "media-playback-allows-inline");
     setting_add(c, "media-playback-requires-user-gesture", TYPE_BOOLEAN, &off, webkit, 0, "media-playback-requires-user-gesture");
     setting_add(c, "media-stream", TYPE_BOOLEAN, &off, webkit, 0, "enable-media-stream");


### PR DESCRIPTION
Older systems like ppc32 struggle with WebKit's JavaScript engine, having this setting turned off enables those systems to access most websites with limited JavaScript functionality instead of simply crashing WebKit on any JS website.

Was tested on Gentoo and ArchPower, works great.

PS: Thank you for creating this browser, it's refreshing to use such a fast browser with a small and simple codebase that people can look into and contribute to!