### PR TITLE
Fix scroll percentage on ppc64le, ppc64, ppc & armv7l (possibly others)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -632,6 +632,15 @@ void vb_statusbar_update(Client *c)
 
     statusbar_update_downloads(c, status);
 
+		/**
+		* These architectures have different kinds of issues with scroll 
+		* percentage, this is a somewhat clean fix that doesn't affect	others.
+		*/
+#if defined(_ARCH_PPC64) || defined(_ARCH_PPC) | defined(_ARCH_ARM)
+		/* force the scroll percent to be 16-bit */
+		c->state.scroll_percent = * (guint16*) ( &c->state.scroll_percent );
+#endif
+
     /* show the scroll status */
     if (c->state.scroll_max == 0) {
         g_string_append(status, " All");
@@ -640,7 +649,7 @@ void vb_statusbar_update(Client *c)
     } else if (c->state.scroll_percent == 100) {
         g_string_append(status, " Bot");
     } else {
-        g_string_append_printf(status, " %hu%%", c->state.scroll_percent);
+        g_string_append_printf(status, " %d%%", c->state.scroll_percent);
     }
 
     gtk_label_set_text(GTK_LABEL(c->statusbar.right), status->str);

--- a/src/main.c
+++ b/src/main.c
@@ -640,7 +640,7 @@ void vb_statusbar_update(Client *c)
     } else if (c->state.scroll_percent == 100) {
         g_string_append(status, " Bot");
     } else {
-        g_string_append_printf(status, " %d%%", c->state.scroll_percent);
+        g_string_append_printf(status, " %hu%%", c->state.scroll_percent);
     }
 
     gtk_label_set_text(GTK_LABEL(c->statusbar.right), status->str);

--- a/src/main.h
+++ b/src/main.h
@@ -174,7 +174,7 @@ struct State {
     MessageType         input_type;
     StatusType          status_type;
     guint64             scroll_max;         /* Maxmimum scrollable height of the document. */
-    guint16             scroll_percent;     /* Current position of the viewport in document (percent). */
+    guint               scroll_percent;     /* Current position of the viewport in document (percent). */
     guint64             scroll_top;         /* Current position of the viewport in document (pixel). */
     char                *title;             /* Window title of the client. */
 

--- a/src/main.h
+++ b/src/main.h
@@ -174,7 +174,7 @@ struct State {
     MessageType         input_type;
     StatusType          status_type;
     guint64             scroll_max;         /* Maxmimum scrollable height of the document. */
-    guint               scroll_percent;     /* Current position of the viewport in document (percent). */
+    guint16             scroll_percent;     /* Current position of the viewport in document (percent). */
     guint64             scroll_top;         /* Current position of the viewport in document (pixel). */
     char                *title;             /* Window title of the client. */
 


### PR DESCRIPTION
Version:         3.6.0-39-ged7d365
WebKit compile:  2.32.3
WebKit run:      2.32.3
GTK compile:     3.24.24
GTK run:         3.24.24
libsoup compile: 2.72.0
libsoup run:     2.72.0
Extension dir:   /home/$USER/.local/lib/vimb

(x86, x86_64, ppc64le)

Version:         3.6.0-34-g652f411
WebKit compile:  2.32.3
WebKit run:      2.32.3
GTK compile:     3.24.30
GTK run:         3.24.30
libsoup compile: 2.74.0
libsoup run:     2.74.0
Extension dir:   /home/$USER/.local/lib/vimb

(ppc64, ppc)

Version:         3.6.0-37-g837ff36
WebKit compile:  2.32.3
WebKit run:      2.32.3
GTK compile:     3.24.5
GTK run:         3.24.5
libsoup compile: 2.64.2
libsoup run:     2.64.2
Extension dir:   /home/pi/.local//lib/vimb

(rpi4)

### Steps to reproduce
Use the browser

### Expected behaviour
Correct scroll percentage shown

### Actual behaviour
Different behavior accross architectures:
(x86, x86_64, and ppc64le using Devuan Linux Chimaera; ppc64 and ppc using Debian Sid; Rpi4 using Raspbian (Debian 10) )

On x86 and x86_64, the values show as expected.

on ppc64le, ppc64, ppc and armv7l, different outcomes are observed, I chose to display the value in hexadecimal, making it easier to find the specific bug.

ppc, ppc64: Lower 2 bytes are always set to 0x0000, upper 2 bytes contain the percentage of scrolling.

ppc64le: Upper two bytes are set to random numbers on each page, lower two bytes contain the percentage of scrolling.

armv7l: Upper two bytes are set to 0xABC0 always, lower bytes are the percentage.

The fix: Using a guint16 instead of guint seems to completely fix the issue without introducing bugs on any architecture.

I can't figure out for the life of me why this is happening, but I'm going to investigate libwegkit2gtk later because I am very sure it's an issue with the library itself.
