### PR TITLE
make invalid command warnings more useful

### DIFF
--- a/src/ex.c
+++ b/src/ex.c
@@ -486,7 +486,7 @@ VbCmdResult ex_run_file(Client *c, const char *filename)
         }
         if ((ex_run_string(c, line, FALSE) & ~CMD_KEEPINPUT) == CMD_ERROR) {
             res = CMD_ERROR | CMD_KEEPINPUT;
-            g_warning("Invalid command in %s: '%s'", filename, line);
+            g_warning("Invalid command in %s line #%u : '%s'", filename, i+1, line);
         }
     }
     g_strfreev(lines);


### PR DESCRIPTION
Added a simple print of line numbers when printing a warning of invalid commands in the config file. Saved me some headache finding that line with only spaces in it.
I considered fixing it so that it doesn't warn on lines with spaces and tabs and considers them empty instead, but it might add more complexity than necessary.