### PR TITLE
New feature: show some settings on statusbar (js, cookies, html5-localstorage)

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1370,6 +1370,12 @@ Whether JavaScript can access the clipboard.
 .B javascript-can-open-windows-automatically (bool)
 Whether JavaScript can open popup windows automatically without user
 interaction.
+.PD
+.RE
+.TP
+.B javascript-enable-markup (bool)
+Whether JavaScript markup is enabled.
+Disabling can help with some older systems (ppc, ppc64, etc.) that don't have complete JavaScript support to run webpages without crashing.
 .TP
 .B geolocation (string)
 Controls website access to the geolocation API {`always', `never', `ask' (display a prompt each time)}
@@ -1474,6 +1480,12 @@ Brazil.
 .TP
 .B status-bar (bool)
 Indicates if the status bar should be shown.
+.PD
+.RE
+.TP
+.B status-bar-show-settings (bool)
+Whether to show settings on the status bar.
+This shows on the right hand of the status bar whether JavaScript, Cookies, and HTML5 LocalStorage are enabled.
 .TP
 .B status-css (string)
 CSS style applied to the status bar on none https pages.
@@ -1538,12 +1550,6 @@ This fills the inputbox with the prefilled download command and replaces
 Whether to enable the XSS auditor.
 This feature filters some kinds of reflective XSS attacks on vulnerable web
 sites.
-.PD
-.RE
-.TP
-.B javascript-enable-markup (bool)
-Whether JavaScript markup is enabled.
-Disabling can help with some older systems (ppc, ppc64, etc.) that don't have complete JavaScript support to run webpages without crashing.
 .
 .
 .SH FILES

--- a/src/main.c
+++ b/src/main.c
@@ -632,6 +632,18 @@ void vb_statusbar_update(Client *c)
 
     statusbar_update_downloads(c, status);
 
+    if ( c->config.statusbar_show_settings ) {
+        /* show js, cookies, and local storage status */
+
+        Setting *js = g_hash_table_lookup(c->config.settings, "scripts");
+        Setting *cookies = g_hash_table_lookup(c->config.settings, "cookie-accept");
+        Setting *local_storage = g_hash_table_lookup(c->config.settings, "html5-local-storage");
+
+        g_string_append_printf(status, " js: %s |", js->value.b ? "on" : "off");
+        g_string_append_printf(status, " cookies: %s |", cookies->value.s);
+        g_string_append_printf(status, " storage: %s", local_storage->value.b ? "on" : "off");
+    }
+
     /* show the scroll status */
     if (c->state.scroll_max == 0) {
         g_string_append(status, " All");

--- a/src/main.h
+++ b/src/main.h
@@ -254,6 +254,7 @@ struct Client {
         gboolean                prevent_newwindow;
         guint                   default_zoom;   /* default zoom level in percent */
         Shortcut                *shortcuts;
+        gboolean                statusbar_show_settings;
     } config;
     struct {
         GSList      *list;

--- a/src/setting.c
+++ b/src/setting.c
@@ -148,6 +148,7 @@ void setting_init(Client *c)
     setting_add(c, "scroll-multiplier", TYPE_INTEGER, &i, internal, 0, &c->config.scrollmultiplier);
     setting_add(c, "home-page", TYPE_CHAR, &SETTING_HOME_PAGE, NULL, 0, NULL);
     i = 2000;
+    setting_add(c, "status-bar-show-settings", TYPE_BOOLEAN, &off, internal, 0, &c->config.statusbar_show_settings);
     /* TODO should be global and not overwritten by a new client */
     setting_add(c, "history-max-items", TYPE_INTEGER, &i, internal, 0, &vb.config.history_max);
     setting_add(c, "editor-command", TYPE_CHAR, &"x-terminal-emulator -e -vi '%s'", NULL, 0, NULL);


### PR DESCRIPTION
I added a new feature that shows the status of JavaScript, cookies, and HTML5 LocalStorage on the right hand side of the statusbar, next to the scroll percentage.
This can be toggled by the setting `status-bar-show-settings`

Before:

![statusbar_before](https://user-images.githubusercontent.com/48805418/134151174-d814eace-5ef8-4ab9-83b5-3baaf16b159d.png)

After:

![statusbar_after](https://user-images.githubusercontent.com/48805418/134151216-25688d59-334e-4a9c-9242-f8b94a4e7b39.png)


I also fixed a small mistake I did before with the man file, "javascript-enable-markup" was not in alphabetical order so I fixed that.