### PR TITLE
Add option for WebKit Intelligent Tracking Prevention

### DIFF
--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -1364,6 +1364,9 @@ CSS style applied to the inputbox in normal state.
 .B input-error-css (string)
 CSS style applied to the inputbox in case of displayed error.
 .TP
+.B intelligent-tracking-prevention (bool)
+Whether WebKit's Intelligent Tracking Prevention (ITP) is enabled.
+.TP
 .B javascript-can-access-clipboard (bool)
 Whether JavaScript can access the clipboard.
 .TP

--- a/src/setting.c
+++ b/src/setting.c
@@ -108,7 +108,9 @@ void setting_init(Client *c)
     setting_add(c, "html5-local-storage", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-local-storage");
     setting_add(c, "hyperlink-auditing", TYPE_BOOLEAN, &off, webkit, 0, "enable-hyperlink-auditing");
     setting_add(c, "images", TYPE_BOOLEAN, &on, webkit, 0, "auto-load-images");
+#if WEBKIT_CHECK_VERSION(2, 30, 0)
     setting_add(c, "intelligent-tracking-prevention", TYPE_BOOLEAN, &off, intelligent_tracking_prevention, 0, NULL);
+#endif
     setting_add(c, "javascript-can-access-clipboard", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-access-clipboard");
     setting_add(c, "javascript-can-open-windows-automatically", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-open-windows-automatically");
 #if WEBKIT_CHECK_VERSION(2, 24, 0)
@@ -571,6 +573,7 @@ static int geolocation(Client *c, const char *name, DataType type, void *value, 
     return CMD_SUCCESS;
 }
 
+#if WEBKIT_CHECK_VERSION(2, 30, 0)
 static int intelligent_tracking_prevention(Client *c, const char *name, DataType type, void *value, void *data)
 {
     WebKitWebContext *ctx = webkit_web_view_get_context(c->webview);
@@ -578,6 +581,7 @@ static int intelligent_tracking_prevention(Client *c, const char *name, DataType
     webkit_website_data_manager_set_itp_enabled(manager, *(gboolean*)value);
     return CMD_SUCCESS;
 }
+#endif
 
 /* This needs to be called before the window is shown for the best chance of
  * success, but it may be called at any time.

--- a/src/setting.c
+++ b/src/setting.c
@@ -61,6 +61,7 @@ static int input_autohide(Client *c, const char *name, DataType type, void *valu
 static int internal(Client *c, const char *name, DataType type, void *value, void *data);
 static int notification(Client *c, const char *name, DataType type, void *value, void *data);
 static int headers(Client *c, const char *name, DataType type, void *value, void *data);
+static int intelligent_tracking_prevention(Client *c, const char *name, DataType type, void *value, void *data);
 static int user_scripts(Client *c, const char *name, DataType type, void *value, void *data);
 static int user_style(Client *c, const char *name, DataType type, void *value, void *data);
 static int statusbar(Client *c, const char *name, DataType type, void *value, void *data);
@@ -107,6 +108,7 @@ void setting_init(Client *c)
     setting_add(c, "html5-local-storage", TYPE_BOOLEAN, &on, webkit, 0, "enable-html5-local-storage");
     setting_add(c, "hyperlink-auditing", TYPE_BOOLEAN, &off, webkit, 0, "enable-hyperlink-auditing");
     setting_add(c, "images", TYPE_BOOLEAN, &on, webkit, 0, "auto-load-images");
+    setting_add(c, "intelligent-tracking-prevention", TYPE_BOOLEAN, &off, intelligent_tracking_prevention, 0, NULL);
     setting_add(c, "javascript-can-access-clipboard", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-access-clipboard");
     setting_add(c, "javascript-can-open-windows-automatically", TYPE_BOOLEAN, &off, webkit, 0, "javascript-can-open-windows-automatically");
 #if WEBKIT_CHECK_VERSION(2, 24, 0)
@@ -566,6 +568,14 @@ static int geolocation(Client *c, const char *name, DataType type, void *value, 
         vb_echo(c, MSG_ERROR, FALSE, "%s must be in [always, ask, never]", name);
         return CMD_ERROR | CMD_KEEPINPUT;
     }
+    return CMD_SUCCESS;
+}
+
+static int intelligent_tracking_prevention(Client *c, const char *name, DataType type, void *value, void *data)
+{
+    WebKitWebContext *ctx = webkit_web_view_get_context(c->webview);
+    WebKitWebsiteDataManager *manager = webkit_web_context_get_website_data_manager(ctx);
+    webkit_website_data_manager_set_itp_enabled(manager, *(gboolean*)value);
     return CMD_SUCCESS;
 }
 


### PR DESCRIPTION
Please let me know if I got the version checks right.
I could only find examples of checking the runtime version in vimb, but the ITP functions were [introduced in 2.30](https://webkitgtk.org/reference/webkit2gtk/unstable/WebKitWebsiteDataManager.html#webkit-website-data-manager-set-itp-enabled) and I guess compilation would fail if I don't check the compile-time version.