### PR TITLE
Add hints for <summary> elements

### DIFF
--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -527,7 +527,7 @@ var hints = Object.freeze((function(){
             var prop,
                 /* holds the xpaths for the different modes */
                 xpathmap = {
-                    otY:     "//*[@href] | //*[@onclick or @tabindex or @class='lk' or @role='link' or @role='button'] | //input[not(@type='hidden' or @disabled or @readonly)] | //textarea[not(@disabled or @readonly)] | //button | //select",
+                    otY:     "//*[@href] | //*[@onclick or @tabindex or @class='lk' or @role='link' or @role='button'] | //input[not(@type='hidden' or @disabled or @readonly)] | //textarea[not(@disabled or @readonly)] | //button | //select | //summary",
                     k:       "//div",
                     e:       "//input[not(@type) or @type='text'] | //textarea",
                     iI:      "//img[@src]",


### PR DESCRIPTION
The [`<summary>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary) element has an implicit ARIA role of `button`, and is typically used to toggle the visibility of content within a `<details>` element.
They are used on Sourcehut among other websites and it's nice to be able to toggle them easily.
There's a demo on the [MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary).