### PR TITLE
Set z-index on hint container to max value

### DIFF
--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -229,7 +229,7 @@ var hints = Object.freeze((function(){
             hDiv.style.position = "fixed";
             hDiv.style.top      = "0";
             hDiv.style.left     = "0";
-            hDiv.style.zIndex   = "225000";
+            hDiv.style.zIndex   = "2147483647";
             hDiv.appendChild(fragment);
             if (doc.body) {
                 doc.body.appendChild(hDiv);


### PR DESCRIPTION
There was a GDPR consent dialog that made itself inaccessible by setting `z-index` to the maximum `i32` value `2147483647`, thereby covering the hint container and hints.
This seems to be the largest value supported in practice.
Setting the hint container's `z-index` to the same value puts in on top, since it is also last in the DOM.