### PR TITLE
README.md: update Gentoo overlays: remove hsoft, add jjakob

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the project page of [Vimb][].
 ## Packages
 
 - Arch Linux: [community/vimb][], [aur/vimb-git][], [aur/vimb-gtk2][]
-- Gentoo: [gentoo-git][], [gentoo][]
+- Gentoo: [tharvik overlay][], [jjakob overlay][]
 - openSUSE: [network/vimb][]
 - pkgsrc: [pkgsrc/www/vimb][], [pkgsrc/wip/vimb-git][]
 - Slackware: [slackbuild/vimb][]
@@ -91,8 +91,8 @@ Information about the license are found in the file LICENSE.
 [aur/vimb-git]:        https://aur.archlinux.org/packages/vimb-git
 [aur/vimb-gtk2]:       https://aur.archlinux.org/packages/vimb-gtk2/
 [community/vimb]:      https://www.archlinux.org/packages/community/x86_64/vimb/
-[gentoo-git]:          https://github.com/tharvik/overlay/tree/master/www-client/vimb
-[gentoo]:              https://github.com/hsoft/portage-overlay/tree/master/www-client/vimb
+[tharvik overlay]:     https://github.com/tharvik/overlay/tree/master/www-client/vimb
+[jjakob overlay]:      https://github.com/jjakob/gentoo-overlay/tree/master/www-client/vimb
 [mail-archive]:        https://sourceforge.net/p/vimb/vimb/vimb-users/ "vimb - mailing list archive"
 [mail]:                https://lists.sourceforge.net/lists/listinfo/vimb-users "vimb - mailing list"
 [network/vimb]:        https://build.opensuse.org/package/show/network/vimb


### PR DESCRIPTION
https://github.com/hsoft is 404 so remove it.
There doesn't seem to be an overlay named "hsoft" in the gentoo overlay
list either.
Add https://github.com/jjakob which has an updated ebuild from the
latest git commit, that is not a live ebuild.

Live ebuilds (version 9999, using git-r3) are considered insecure since there's no verification of the downloaded source. Using a versioned ebuild with SRC_URI is secure as the checksum of the source archive is saved in the Manifest.
Since the tharvik overlay only has 3.6.0 and 9999 ebuilds, I was stuck with either an old version, or an insecure ebuild, so I created an ebuild with the latest git commit as the source.