### PR TITLE
Read-it-Later Queue Improvements

### DIFF
--- a/src/ex.c
+++ b/src/ex.c
@@ -1301,6 +1301,8 @@ static gboolean complete(Client *c, short direction)
             switch (arg->code) {
                 case EX_OPEN:
                 case EX_TABOPEN:
+                case EX_QPUSH:
+                case EX_QUNSHIFT:
                     sort = FALSE;
                     if (*token == '!') {
                         found = bookmark_fill_completion(store, token + 1);

--- a/src/normal.c
+++ b/src/normal.c
@@ -62,6 +62,8 @@ static VbResult normal_hint(Client *c, const NormalCmdInfo *info);
 static VbResult normal_do_hint(Client *c, const char *prompt);
 static VbResult normal_increment_decrement(Client *c, const NormalCmdInfo *info);
 static VbResult normal_input_open(Client *c, const NormalCmdInfo *info);
+static VbResult normal_input_queue(Client *c, const NormalCmdInfo *info);
+static VbResult normal_input_qunshift(Client *c, const NormalCmdInfo *info);
 static VbResult normal_mark(Client *c, const NormalCmdInfo *info);
 static VbResult normal_navigate(Client *c, const NormalCmdInfo *info);
 static VbResult normal_open_clipboard(Client *c, const NormalCmdInfo *info);
@@ -163,13 +165,13 @@ static struct {
 /* N   0x4e */ {normal_search},
 /* O   0x4f */ {normal_input_open},
 /* P   0x50 */ {normal_open_clipboard},
-/* Q   0x51 */ {NULL},
+/* Q   0x51 */ {normal_input_queue},
 /* R   0x52 */ {normal_navigate},
 /* S   0x53 */ {NULL},
 /* T   0x54 */ {normal_input_open},
 /* U   0x55 */ {normal_open},
 /* V   0x56 */ {NULL},
-/* W   0x57 */ {NULL},
+/* W   0x57 */ {normal_input_qunshift},
 /* X   0x58 */ {NULL},
 /* Y   0x59 */ {normal_yank},
 /* Z   0x5a */ {NULL},
@@ -195,13 +197,13 @@ static struct {
 /* n   0x6e */ {normal_search},
 /* o   0x6f */ {normal_input_open},
 /* p   0x70 */ {normal_open_clipboard},
-/* q   0x71 */ {NULL},
+/* q   0x71 */ {normal_input_queue},
 /* r   0x72 */ {normal_navigate},
 /* s   0x73 */ {NULL},
 /* t   0x74 */ {normal_input_open},
 /* u   0x75 */ {normal_open},
 /* v   0x76 */ {NULL},
-/* w   0x77 */ {NULL},
+/* w   0x77 */ {normal_input_qunshift},
 /* x   0x78 */ {NULL},
 /* y   0x79 */ {normal_yank},
 /* z   0x7a */ {normal_zoom},
@@ -542,6 +544,36 @@ static VbResult normal_input_open(Client *c, const NormalCmdInfo *info)
      * commands modes input change handler */
     vb_enter_prompt(c, 'c', ":", FALSE);
 
+    return RESULT_COMPLETE;
+}
+
+static VbResult normal_input_queue(Client *c, const NormalCmdInfo *info)
+{
+#ifdef FEATURE_QUEUE
+    if (info->key == 'q') {
+        vb_echo(c, MSG_NORMAL, FALSE, ":%s ", "qpush");
+    } else {
+        vb_echo(c, MSG_NORMAL, FALSE, ":%s %s", "qpush", c->state.uri);
+    }
+    /* switch mode after setting the input text to not trigger the
+     * commands modes input change handler */
+    vb_enter_prompt(c, 'c', ":", FALSE);
+#endif
+    return RESULT_COMPLETE;
+}
+
+static VbResult normal_input_qunshift(Client *c, const NormalCmdInfo *info)
+{
+#ifdef FEATURE_QUEUE
+    if (info->key == 'w') {
+        vb_echo(c, MSG_NORMAL, FALSE, ":%s ", "qunshift");
+    } else {
+        vb_echo(c, MSG_NORMAL, FALSE, ":%s %s", "qunshift", c->state.uri);
+    }
+    /* switch mode after setting the input text to not trigger the
+     * commands modes input change handler */
+    vb_enter_prompt(c, 'c', ":", FALSE);
+#endif
     return RESULT_COMPLETE;
 }
 


### PR DESCRIPTION
I've been finding the Read-it-Later Queue to be very useful and at this point it has almost completely replaced the need to have dozens of tabs. I've made a few changes to help make it easier to use for certain use cases, offering here in the event that the changes are desirable.

First is to allow bookmark completion with the `:qpush` and `:qunshift` commands. I use this feature a lot for reading sites that update frequently (mainly Twitter feeds as I don't have an account).

Second is new key combinations to queuing items. 'q' and 'w' which prompt the user to `:qpush` and `:qunshift` respectively. 'Q' and 'W' do the same but also include the current URI. I find the latter two keys helpful for when I'm consuming my queue. 'W' can un-pop the last item in case I want to keep it. 'Q' is very helpful in case I ever reach an item I would like to keep queued but don't want to consume just yet.