### PR TITLE
main: fix compilation with FEATURE_NO_XEMBED

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -833,10 +833,10 @@ static void client_show(WebKitWebView *webview, Client *c)
 
     gtk_widget_show_all(c->window);
 
+#ifndef FEATURE_NO_XEMBED
     char *wid;
     wid = g_strdup_printf("%d", (int)GDK_WINDOW_XID(gtk_widget_get_window(c->window)));
     g_setenv("VIMB_WIN_ID", wid, TRUE);
-#ifndef FEATURE_NO_XEMBED
     /* set the x window id to env */
     if (vb.embed) {
         char *xid;
@@ -846,8 +846,8 @@ static void client_show(WebKitWebView *webview, Client *c)
     } else {
         g_setenv("VIMB_XID", wid, TRUE);
     }
-#endif
     g_free(wid);
+#endif
 
     /* start client in normal mode */
     vb_enter(c, 'n');


### PR DESCRIPTION
When FEATURE_NO_XEMBED is defined then we don't support using the Xembed interface, which will cause us to set the `VIMB_XID` envvar. With 55fb9cc (Add new env VIMB_WIN_ID to hold the gtk window id., 2021-01-25) a related feature was added that causes us to expose the Gtk window ID via the `VIMB_WIN_ID` environment variable. This feature also depends on X-specific information because it uses `GDK_WINDOW_XID()` to derive the window ID. This change thus broke Wayland-only environments.

Fix compilation by extending the `ifdef` to guard the logic that both sets the `VIMB_XID` and the `VIMB_WIN_ID`.