### PR TITLE
Port to webkit-gtk 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
     gh-pages
 
 language: c
-dist: bionic
+dist: jammy
 sudo: required
 
 compiler:
@@ -12,6 +12,6 @@ compiler:
 
 before_install:
   - sudo apt-get update -q
-  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends libwebkit2gtk-4.0-dev
+  - sudo apt-get install -y --allow-unauthenticated --no-install-recommends libwebkit2gtk-4.1-dev
 
 script: make options && make -j test

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the project page of [Vimb][].
 ## dependencies
 
 - gtk+-3.0
-- webkit2gtk-4.0 >= 2.20.x
+- webkit2gtk-4.1
 - gst-libav, gst-plugins-good (optional, for media decoding among other things)
 
 ## Install

--- a/config.mk
+++ b/config.mk
@@ -17,7 +17,7 @@ SRCDIR  = src
 DOCDIR  = doc
 
 # used libs
-LIBS = gtk+-3.0 'webkit2gtk-4.0 >= 2.20.0'
+LIBS = gtk+-3.0 webkit2gtk-4.1
 
 # setup general used CFLAGS
 CFLAGS   += -std=c99 -pipe -Wall -fPIC
@@ -34,9 +34,9 @@ endif
 
 # flags used to build webextension
 EXTTARGET   = webext_main.so
-EXTCFLAGS   = ${CFLAGS} $(shell pkg-config --cflags webkit2gtk-web-extension-4.0)
+EXTCFLAGS   = ${CFLAGS} $(shell pkg-config --cflags webkit2gtk-web-extension-4.1)
 EXTCPPFLAGS = $(CPPFLAGS)
-EXTLDFLAGS  = ${LDFLAGS} $(shell pkg-config --libs webkit2gtk-web-extension-4.0) -shared
+EXTLDFLAGS  = ${LDFLAGS} $(shell pkg-config --libs webkit2gtk-web-extension-4.1) -shared
 
 # flags used for the main application
 CFLAGS     += $(shell pkg-config --cflags $(LIBS))

--- a/src/main.c
+++ b/src/main.c
@@ -133,19 +133,25 @@ struct Vimb vb;
 gboolean vb_download_set_destination(Client *c, WebKitDownload *download,
     char *suggested_filename, const char *path)
 {
-    char *download_path, *dir, *file, *uri, *basename = NULL,
-         *decoded_uri = NULL;
-    const char *download_uri;
+    char *download_path, *dir, *file, *uri, *basename = NULL;
+
     download_path = GET_CHAR(c, "download-path");
 
     if (!suggested_filename || !*suggested_filename) {
+        const char *download_uri;
+        GUri *parsed_uri = NULL;
+        char *decoded_uri;
+
         /* Try to find a matching name if there is no suggested filename. */
         download_uri = webkit_uri_request_get_uri(webkit_download_get_request(download));
-        decoded_uri  = soup_uri_decode(download_uri);
+        parsed_uri   = g_uri_parse(download_uri, G_URI_FLAGS_NONE, NULL);
+        decoded_uri  = g_uri_to_string(parsed_uri);
         basename     = g_filename_display_basename(decoded_uri);
-        g_free(decoded_uri);
 
         suggested_filename = basename;
+
+        g_uri_unref(parsed_uri);
+        g_free(decoded_uri);
     }
 
     /* Prepare the path to save the download. */

--- a/src/shortcut.c
+++ b/src/shortcut.c
@@ -92,7 +92,7 @@ char *shortcut_get_uri(Shortcut *sc, const char *string)
     max_num = get_max_placeholder(tmpl);
     /* if there are only $0 placeholders we don't need to split the parameters */
     if (max_num == 0) {
-        quoted_param = soup_uri_encode(query, "&+");
+        quoted_param = g_uri_escape_string(query, NULL, TRUE);
         uri          = util_str_replace("$0", quoted_param, tmpl);
         g_free(quoted_param);
 
@@ -149,7 +149,7 @@ char *shortcut_get_uri(Shortcut *sc, const char *string)
         if (token->len) {
             char *new;
 
-            quoted_param = soup_uri_encode(token->str, "&+");
+            quoted_param = g_uri_escape_string(token->str, NULL, TRUE);
             new = util_str_replace((char[]){'$', current_num + '0', '\0'}, quoted_param, uri);
             g_free(quoted_param);
             g_free(uri);

--- a/src/util.c
+++ b/src/util.c
@@ -803,9 +803,9 @@ char *util_sanitize_filename(char *filename)
  */
 char *util_sanitize_uri(const char *uri_str)
 {
-    SoupURI *uri;
     char *sanitized_uri;
     char *for_display;
+    GUri *uri;
 
     if (!uri_str) {
         return NULL;
@@ -825,9 +825,9 @@ char *util_sanitize_uri(const char *uri_str)
         return for_display;
     }
 
-    uri           = soup_uri_new(for_display);
-    sanitized_uri = soup_uri_to_string(uri, FALSE);
-    soup_uri_free(uri);
+    uri           = g_uri_parse(for_display, G_URI_FLAGS_NONE, NULL);
+    sanitized_uri = g_uri_to_string_partial(uri, G_URI_HIDE_PASSWORD);
+    g_uri_unref(uri);
     g_free(for_display);
 
     return sanitized_uri;


### PR DESCRIPTION
The webkit-gtk project has released a new minor version bump of their
API with version 4.1. The difference between 4.0 and 4.1 is that the
former links against libsoup 2.x, whereas the latter links against
libsoup 3.0 and newer. As libsoup has introduced backwards-incompatible
changes in 3.0 it will cause the process to hard-crash if a program is
linked against both libraries at the same time.

This MR ports vimb to libsoup 3.0 and then converts to link against webkit-gtk 4.1.