### PR TITLE
Update default user-agent to WebKitGTK 2.40.0 default

### DIFF
--- a/src/setting.c
+++ b/src/setting.c
@@ -80,7 +80,7 @@ void setting_init(Client *c)
     gboolean on = TRUE, off = FALSE;
 
     c->config.settings = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)setting_free);
-    setting_add(c, "user-agent", TYPE_CHAR, &"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Safari/605.1.15 " PROJECT "/" VERSION, webkit, 0, "user-agent");
+    setting_add(c, "user-agent", TYPE_CHAR, &"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15 " PROJECT "/" VERSION, webkit, 0, "user-agent");
     /* TODO use the real names for webkit settings */
     i = 14;
     setting_add(c, "accelerated-2d-canvas", TYPE_BOOLEAN, &off, webkit, 0, "enable-accelerated-2d-canvas");


### PR DESCRIPTION
Fixes the "your browser is out of date" error some sites show (Cloudflare).