### PR TITLE
Escape special keys in mappings using backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Allow special keys to be escaped in mappings using `\`. For example, `\<C-R>`
+  represents the key sequence `<`, `C`, `-`, `R`, `>`.
+* Add `<Bslash>` as an alias for `\` in mappings. For example, `<Bslash><C-R>`
+  represents the key sequence `\` followed by CTRL-R.
 
 ## [3.7.0] - 2023-06-19
 ### Added

--- a/doc/vimb.1
+++ b/doc/vimb.1
@@ -572,6 +572,9 @@ number of keys have no visual representation, a special notation is required.
 As special key names have the format \fI<...>\fP.
 The following special keys can be used: <Left>, <Up>, <Right>, <Down>
 for the cursor keys, <Tab>, <Esc>, <CR>, <Space>, <BS>, <F1>-<F12> and <C-A>-<C-Z>.
+If you want an actual sequence of keys like "<", "C", "R", ">" then
+escape with a backslash: "\<CR>". If you want a backslash followed by a special
+key then use <Bslash>.
 .TP
 .PD 0
 .BI ":nm[ap] {" lhs "} {" rhs }
@@ -1554,6 +1557,9 @@ it might change the behaviour by adding or changing mappings.
 .IP ":set x-hint-command=:sh! curl -e <C-R>% <C-R>;"
 This fills the inputbox with the prefilled download command and replaces
 `<C-R>%' with the current URI and `<C-R>;' with the URI of the hinted element.
+.IP ":nnoremap ;f :set x-hint-command=:sh! firefox '\<C-R>;\<CR><CR>;x"
+This makes the key sequence ";f" start hinting and then open the hinted URI in
+firefox.
 .PD
 .RE
 .TP

--- a/src/map.c
+++ b/src/map.c
@@ -79,6 +79,7 @@ static struct {
     char *ch;
     int  chlen;
 } key_labels[] = {
+    {"<Bslash>",        8, "\\",         1},
     {"<CR>",            4, "\x0d",       1},
     {"<Tab>",           5, "\t",         1},
     {"<S-Tab>",         7, CSI_STR "kB", 3},
@@ -435,6 +436,15 @@ static char *convert_keys(const char *in, int inlen, int *len)
 
     *len = 0;
     for (p = in; p < &in[inlen]; p++) {
+        /* if we encounter the sequence \< we replace it with just < but act
+         * like it's a non-special character */
+        if (*p == '\\' && p+1 < &in[inlen] && *(p+1) == '<') {
+            g_string_append_len(str, p+1, 1);
+            *len += 1;
+            ++p;
+            continue;
+        }
+
         /* if it starts not with < we can add it literally */
         if (*p != '<') {
             g_string_append_len(str, p, 1);


### PR DESCRIPTION
* Interpret the syntax `\<C-R>` as representing the literal key sequence `<`, `C`, `-`, `R`, `>`.
* Add a `<Bslash>` special key so that e.g. the syntax `<Bslash><C-R>` is interpreted as the key sequence `\` followed by CTRL-R.

My personal use case is the following mapping:
```
:nnoremap ;f :set x-hint-command=:sh! firefox '\<C-R>;'\<CR><CR>;x
```
this mapping starts hint mode and then opens the hinted URI in Firefox.

Closes #753