### PR TITLE
Check return value of ext_proxy_eval_script_sync.

### DIFF
--- a/src/ext-proxy.c
+++ b/src/ext-proxy.c
@@ -250,6 +250,13 @@ char *ext_proxy_get_current_selection(Client *c)
 
     js       = g_strdup_printf("getSelection().toString();");
     jsreturn = ext_proxy_eval_script_sync(c, js);
+
+    if (jsreturn == NULL) {
+        g_warning("cannot get current selection: failed to evaluate js");
+        g_free(js);
+        return NULL;
+    }
+
     g_variant_get(jsreturn, "(bs)", &success, &selection);
     g_free(js);
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -453,6 +453,10 @@ static VbResult normal_focus_last_active(Client *c, const NormalCmdInfo *info)
     gboolean focused;
 
     variant = ext_proxy_eval_script_sync(c, "vimb_input_mode_element.focus();");
+    if (variant == NULL) {
+    	g_warning("cannot get current selection: failed to evaluate js");
+    	return RESULT_ERROR;
+    }
     g_variant_get(variant, "(bs)", &focused, NULL);
     if (!focused) {
         ext_proxy_focus_input(c);


### PR DESCRIPTION
One of the two added checks fixes #745.

Caveat: I don't understand what the function `normal_focus_last_active` is supposed to return (and more generally don't know much about this codebase). I hope `RESULT_ERROR` is appropriate in this case.

FYI, I can trigger the other added check by going to https://www.facebook.com/ (I'm logged in) and then pressing "i". "i" continues to trigger the error even after I navigate to another page after that. It looks like something breaks when I visit that site (and some others). A warning is printed when `ext_proxy_eval_script_sync` is called: : `** (vimb:43081): WARNING **: 16:11:29.669: Failed dbus method EvalJs: The connection is closed`. Maybe I'll look into that separately.