### PR TITLE
Allow overriding of GDK window color

### DIFF
--- a/src/config.def.h
+++ b/src/config.def.h
@@ -45,6 +45,8 @@
 #define SHOWCMD_LEN                 10
 /* css applied to the gui elements regardless of user's settings */
 #define GUI_STYLE_CSS_BASE          "#input text{background-color:inherit;color:inherit;caret-color:@color;font:inherit;}"
+/* define this to set the initial background color for the GTK window */
+#define GUI_WINDOW_BACKGROUND_COLOR "#FFFFFF"
 
 /* default font size for fonts in webview */
 #define SETTING_DEFAULT_FONT_SIZE             16

--- a/src/main.c
+++ b/src/main.c
@@ -882,6 +882,15 @@ static GtkWidget *create_window(Client *c)
     }
 #endif
 
+#ifdef GUI_WINDOW_BACKGROUND_COLOR
+    {
+        // force setting background color to prevent white flashes in dark mode
+        GdkRGBA color;
+        gdk_rgba_parse (&color, GUI_WINDOW_BACKGROUND_COLOR);
+        gtk_widget_override_background_color(window, GTK_STATE_FLAG_NORMAL, &color);
+    }
+#endif
+
     g_object_connect(
             G_OBJECT(window),
             "signal::destroy", G_CALLBACK(on_window_destroy), c,


### PR DESCRIPTION
This prevents a white flash for example when using dark mode.

Fixes #594