### PR TITLE
Improve search performance

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -69,8 +69,7 @@ gboolean command_search(Client *c, const Arg *arg, bool commit)
             vb_echo(c, MSG_NORMAL, FALSE, "");
         }
 
-        c->state.search.active  = FALSE;
-        c->state.search.matches = 0;
+        c->state.search.active = FALSE;
 
         vb_statusbar_update(c);
 
@@ -107,6 +106,7 @@ gboolean command_search(Client *c, const Arg *arg, bool commit)
          * depends on the most recent selection or caret position (even when
          * caret browsing is disabled). */
         if (commit) {
+            c->state.search.awaited_matches_updates++;
             webkit_find_controller_search(c->finder, "", WEBKIT_FIND_OPTIONS_NONE, G_MAXUINT);
         }
 
@@ -117,15 +117,12 @@ gboolean command_search(Client *c, const Arg *arg, bool commit)
             c->state.search.last_query = g_strdup(query);
         }
 
-        webkit_find_controller_count_matches(c->finder, query,
-                WEBKIT_FIND_OPTIONS_CASE_INSENSITIVE |
-                WEBKIT_FIND_OPTIONS_WRAP_AROUND,
-                G_MAXUINT);
+        c->state.search.awaited_matches_updates++;
         webkit_find_controller_search(c->finder, query,
                 WEBKIT_FIND_OPTIONS_CASE_INSENSITIVE |
                 WEBKIT_FIND_OPTIONS_WRAP_AROUND |
                 (direction > 0 ?  WEBKIT_FIND_OPTIONS_NONE : WEBKIT_FIND_OPTIONS_BACKWARDS),
-                G_MAXUINT);
+                (!commit && arg->s ? INCSEARCH_MATCHES_LIMIT : G_MAXUINT));
 
         c->state.search.active    = TRUE;
         c->state.search.direction = direction;

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -48,6 +48,8 @@
 /* define this to set the initial background color for the GTK window */
 #define GUI_WINDOW_BACKGROUND_COLOR "#FFFFFF"
 
+#define INCSEARCH_MATCHES_LIMIT 1000
+
 /* default font size for fonts in webview */
 #define SETTING_DEFAULT_FONT_SIZE             16
 #define SETTING_DEFAULT_MONOSPACE_FONT_SIZE   13

--- a/src/main.h
+++ b/src/main.h
@@ -191,10 +191,11 @@ struct State {
     gboolean            is_fullscreen;
 
     struct {
-        gboolean    active;         /* indicate if there is a active search */
-        short       direction;      /* last direction 1 forward, -1 backward */
-        int         matches;        /* number of matching search results */
-        char        *last_query;    /* last search query */
+        gboolean    active;                  /* indicate if there is a active search */
+        short       direction;               /* last direction 1 forward, -1 backward */
+        int         matches;                 /* number of matching search results */
+        int         awaited_matches_updates;
+        char        *last_query;             /* last search query */
     } search;
     struct {
         guint64         pos;


### PR DESCRIPTION
If incsearch is enabled Vimb does searching on each keystroke. It looks like WebKit does not abort previous searches. It leads to very poor search performance on huge documents like in the #762. My solution to this problem is to limit each incsearch up to INCSEARCH_MATCHES_LIMIT matches. Also the "webkit_find_controller_count_matches" call and the "counted-matches" callback were replaced by 2 new callbacks (~1.5x faster on my machine).