### PR TITLE
Fix incorrect pageid and dbusproxy handling

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -300,6 +300,7 @@ struct Vimb {
     gboolean    incognito;
 
     WebKitWebContext *webcontext;
+    GHashTable *page_connections;   /* stores dbus connection for each WebKitWebPage */
 };
 
 gboolean vb_download_set_destination(Client *c, WebKitDownload *download,

--- a/src/webextension/ext-main.c
+++ b/src/webextension/ext-main.c
@@ -526,7 +526,13 @@ static void on_page_created(WebKitWebExtension *extension, WebKitWebPage *webpag
  */
 static void on_web_page_document_loaded(WebKitWebPage *webpage, gpointer extension)
 {
-    /* If there is a hashtable of known document - detroy this and create a
+    guint64 pageid = webkit_web_page_get_id(webpage);
+
+    webkit_web_page_send_message_to_view(webpage,
+            webkit_user_message_new("page-document-loaded", NULL), NULL, NULL,
+            (gpointer) pageid);
+
+    /* If there is a hashtable of known document - destroy this and create a
      * new hashtable. */
     if (ext.documents) {
         g_hash_table_unref(ext.documents);


### PR DESCRIPTION
In some cases (such as presence [cross-origin opener policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy) http response header with "same-origin" value) WebKit creates new WebProcess, WebPage and WebExtension to enhance [site isolation](https://docs.webkit.org/Deep%20Dive/SiteIsolation.html). At this moment Vimb doesnt properly handle such cases and it leads to broken hints, scroll keys, scroll position in statusbar. As soon as this state is reached, every page will have these problems. Other webkit-based browsers (surf, luakit) have this problem too.

Examples of isolated sites:
- https://archlinux.org
- https://pinafore.social
- https://forums.unrealengine.com
- google signin account chooser (cant provide url, it requires some get parameters)

This PR leads to proper client's pageid and dbusproxy handling.
resolves #769, resolves #709 

There is at least one more bug related to the site isolation. Open a normal site (for example, t2sde.org), then open an isolated site, then go back and forward in the history (Ctrl-o Ctrl-i). Webkit wont show you an isolated site, it creates new WebExtensions over and over again causing high cpu usage until you go back in history. It seems like [that PR](https://github.com/WebKit/WebKit/pull/49354) may fix this problem but I'm not sure. Most likely I will check this after next WebKit version will be released.