### PR TITLE
Add FEATURE_HISTORY_WITHOUT_HOME_PAGE

### DIFF
--- a/src/config.def.h
+++ b/src/config.def.h
@@ -28,6 +28,8 @@
 #define FEATURE_QUEUE
 /* disable X window embedding */
 /* #define FEATURE_NO_XEMBED */
+/* don't write the home-page uri in the history file */
+/* #define FEATURE_HISTORY_WITHOUT_HOME_PAGE */
 
 #ifdef FEATURE_WGET_PROGRESS_BAR
 /* chars to use for the progressbar */

--- a/src/main.c
+++ b/src/main.c
@@ -1586,7 +1586,12 @@ static void on_webview_load_changed(WebKitWebView *webview,
             autocmd_run(c, AU_LOAD_FINISHED, raw_uri, NULL);
 #endif
             c->state.progress = 100;
-            if (uri && strncmp(uri, "about:", 6)) {
+            if (uri
+                && strncmp(uri, "about:", 6)
+#ifdef FEATURE_HISTORY_WITHOUT_HOME_PAGE
+                && strcmp(uri, GET_CHAR(c, "home-page"))
+#endif
+            ) {
                 history_add(c, HISTORY_URL, uri, webkit_web_view_get_title(webview));
             }
             break;


### PR DESCRIPTION
Some users may prefer their history file isn't flooded by home-page uri records