### PR TITLE
Fix hard-codes pkg-config

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@ LIBDIR           := $(DESTDIR)$(PREFIX)/lib/vimb
 RUNPREFIX        := $(PREFIX)
 EXTENSIONDIR     := $(RUNPREFIX)/lib/vimb
 OS               := $(shell uname -s)
-PKG_CONFIG       ?= $(PKG_CONFIG)
+PKG_CONFIG       ?= pkg-config
 
 # define some directories
 SRCDIR  = src


### PR DESCRIPTION
vimb fails to cross-build due to hard-coding pkg-config in config.mk. The right arch-triplet prefixed pkg-config is passed by default in cross builds which this should use.

See debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1110406