### PR TITLE
Fix input mode bugs

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1710,7 +1710,7 @@ static void on_webview_load_changed(WebKitWebView *webview,
             /* In case of HTTP authentication request we ignore the focus
              * changes so that the input mode can be set for the
              * authentication request. If the authentication dialog is filled
-             * or aborted the load will be commited. So this seems to be the
+             * or aborted the load will be committed. So this seems to be the
              * right place to remove the flag. */
             c->mode->flags &= ~FLAG_IGNORE_FOCUS;
 #ifdef FEATURE_AUTOCMD
@@ -1872,7 +1872,7 @@ static gboolean on_webview_authenticate(WebKitWebView *webview,
     /* Don't change the mode if we are in pass through mode. */
     if (c->mode->id == 'n') {
         vb_enter(c, 'i');
-        /* Make sure we do not switch back to normal mode in case a previos
+        /* Make sure we do not switch back to normal mode in case a previous
          * page is open and looses the focus. */
         c->mode->flags |= FLAG_IGNORE_FOCUS;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -1694,8 +1694,11 @@ static void on_webview_load_changed(WebKitWebView *webview,
             /* Make sure hinting is cleared before the new page is loaded.
              * Without that vimb would still be in hinting mode after hinting
              * was started and some links was clicked my mouse. Even if there
-             * could not hints be shown. */
-            if (c->mode->flags & FLAG_HINTING) {
+             * could not hints be shown.
+             * Also leave input mode. Otherwise, hitting enter in an input box
+             * on a search engine page will take you to a results page in input
+             * mode. */
+            if (c->mode->flags & FLAG_HINTING || c->mode->id == 'i') {
                 vb_enter(c, 'n');
             }
             break;

--- a/src/normal.c
+++ b/src/normal.c
@@ -455,8 +455,8 @@ static VbResult normal_focus_last_active(Client *c, const NormalCmdInfo *info)
     variant = ext_proxy_eval_script_sync(c,
         "typeof vimb_input_mode_element !== 'undefined' && vimb_input_mode_element ? vimb_input_mode_element.focus() : false;");
     if (variant == NULL) {
-    	g_warning("cannot get current selection: failed to evaluate js");
-    	return RESULT_ERROR;
+        g_warning("cannot set focus on the last focused element: failed to evaluate js");
+        return RESULT_ERROR;
     }
     g_variant_get(variant, "(bs)", &focused, NULL);
     g_variant_unref(variant);

--- a/src/normal.c
+++ b/src/normal.c
@@ -450,21 +450,26 @@ static VbResult normal_fire(Client *c, const NormalCmdInfo *info)
 static VbResult normal_focus_last_active(Client *c, const NormalCmdInfo *info)
 {
     GVariant *variant;
-    gboolean focused;
+    gboolean success;
+    char *script_result;
 
     variant = ext_proxy_eval_script_sync(c,
-        "typeof vimb_input_mode_element !== 'undefined' && vimb_input_mode_element ? vimb_input_mode_element.focus() : false;");
+        "if (typeof vimb_input_mode_element !== 'undefined' && vimb_input_mode_element) { vimb_input_mode_element.focus(); 1; } else 0;");
     if (variant == NULL) {
         g_warning("cannot set focus on the last focused element: failed to evaluate js");
         return RESULT_ERROR;
     }
-    g_variant_get(variant, "(bs)", &focused, NULL);
+    g_variant_get(variant, "(bs)", &success, &script_result);
     g_variant_unref(variant);
-    if (!focused) {
+    if (!success) {
+        return RESULT_ERROR;
+    }
+
+    if (*script_result == '0') {
         ext_proxy_focus_input(c);
     }
 
-    return RESULT_ERROR;
+    return RESULT_COMPLETE;
 }
 
 static VbResult normal_g_cmd(Client *c, const NormalCmdInfo *info)

--- a/src/setting.c
+++ b/src/setting.c
@@ -747,9 +747,21 @@ static int user_scripts(Client *c, const char *name, DataType type, void *value,
 
     /* Inject the global scripts: hints, scroll, scroll observer, and focus tracking.
      * Focus tracking detects when editable elements gain/lose focus to
-     * automatically switch vimb between normal and input modes. */
+     * automatically switch vimb between normal and input modes.
+     *
+     * Focus tracking script should be injected at the start of a document
+     * since document may have an input or textarea with an autofocus
+     * attribute or there may be a script in the middle of a document that sets
+     * focus to some element. */
     script = webkit_user_script_new(
-            JS_HINTS " " JS_SCROLL " " JS_SCROLL_OBSERVER " " JS_FOCUS_TRACKING,
+            JS_FOCUS_TRACKING,
+            WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
+            WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, NULL, NULL);
+    webkit_user_content_manager_add_script(ucm, script);
+    webkit_user_script_unref(script);
+
+    script = webkit_user_script_new(
+            JS_HINTS " " JS_SCROLL " " JS_SCROLL_OBSERVER,
             WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
             WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END, NULL, NULL);
     webkit_user_content_manager_add_script(ucm, script);


### PR DESCRIPTION
Fixes several bugs:
- hitting 'i' do not focus first focusable element (it should do this if there is no last focused element acording to the manpage);
- Vimb doesn't leave input mode on new page. Open google.com, type something in the search box and hit Enter. Vimb will be in the input mode on a results page and will behave like it's in the pass-through mode.
- Vimb doesn't handle focus changes before document has been loaded. Open google.com and you will see that webkit set focus to the search box (because the input has autofocus attribute) but Vimb is still in the normal mode.