### PR TITLE
Fix g;{mode} extended hinting opens links in background tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   The command history and `:` register were saved after the command executed,
   so closing the current tab first freed the client before the write.
   Also fixed a secondary use-after-free in the command-line activation handler
+* Fix `g;{mode}` extended hinting opens links in background tabs
 
 ## [4.0.0]
 ### Added

--- a/src/hints.c
+++ b/src/hints.c
@@ -102,6 +102,19 @@ void hints_clear(Client *c)
          * already cleared, the link opens in the current tab instead of a
          * new tab. The flag will naturally be consumed when the navigation
          * happens, or will be harmless if no navigation occurs. */
+        /* If this was a g-mode (extended) hinting session, the
+         * open_in_new_tab / open_in_background flags were kept set across
+         * multiple fires so every hinted element opens in a background tab.
+         * When the session ends without consuming the flags (e.g. the user
+         * aborts with ESC after having fired nothing), reset them so a later
+         * normal navigation does not unexpectedly open a background tab. This
+         * must not run unconditionally: in regular ;t mode the flags are
+         * cleared by decide_navigation_action when the pending navigation
+         * fires, and clearing them here would race that navigation. */
+        if (hints.gmode) {
+            c->state.open_in_new_tab = FALSE;
+            c->state.open_in_background = FALSE;
+        }
         vb_input_set_text(c, "");
 
         /* Run this sync else we would disable JavaScript before the hint is
@@ -117,6 +130,16 @@ void hints_clear(Client *c)
             g_object_set(G_OBJECT(setting), "enable-javascript", hints.allow_javascript, NULL);
         }
     }
+}
+
+/**
+ * Return whether the currently active hinting runs in extended (g-) mode.
+ *
+ * @return TRUE if the active hint session was started in g-mode hinting.
+ */
+gboolean hints_is_gmode(void)
+{
+    return hints.gmode;
 }
 
 void hints_create(Client *c, const char *input)
@@ -135,13 +158,19 @@ void hints_create(Client *c, const char *input)
     if (!(c->mode->flags & FLAG_HINTING)) {
         c->mode->flags |= FLAG_HINTING;
 
-        /* For 't' mode (open in new tab), set open_in_new_tab flag on client.
-         * This is needed because the JavaScript navigation may start before
-         * the "DONE:" result is processed, due to the async nature of
-         * WebKitUserMessage. Using client state instead of mode flag because
-         * modes are shared across all tabs. The flag will be cleared by
-         * decide_navigation_action after opening the new tab. */
-        if (hints.mode == 't') {
+        /* For 't' and 'o' in g-mode (extended hint mode), set flags so that
+         * the link is opened in a new background tab that does NOT steal focus.
+         * This lets the user continue hinting more links without leaving the
+         * current page or hint mode. In g-mode, 'o' opens a bg tab (unlike
+         * regular ';o' which navigates the current tab). */
+        if (hints.gmode) {
+            /* In extended hint mode, even 'o' opens in a background tab */
+            if (hints.mode == 'o' || hints.mode == 't') {
+                c->state.open_in_new_tab = TRUE;
+                c->state.open_in_background = TRUE;
+            }
+        } else if (hints.mode == 't') {
+            /* Regular non-g 't' mode: open in new tab, activate it */
             c->state.open_in_new_tab = TRUE;
         }
 
@@ -402,7 +431,13 @@ static gboolean hint_function_check_result(Client *c, GVariant *return_value)
             case 'i':
             case 'I':
                 a.s = v;
-                a.i = (hints.mode == 'I') ? TARGET_TAB : TARGET_CURRENT;
+                if (hints.mode == 'I') {
+                    /* 'I': open image in new tab. In g-mode (extended hint mode),
+                     * use background tab so focus stays on current page/hints. */
+                    a.i = hints.gmode ? TARGET_TAB_BG : TARGET_TAB;
+                } else {
+                    a.i = TARGET_CURRENT;
+                }
                 vb_load_uri(c, &a);
                 break;
 

--- a/src/hints.h
+++ b/src/hints.h
@@ -28,6 +28,7 @@ void hints_fire(Client *c);
 void hints_follow_link(Client *c, gboolean back, int count);
 void hints_increment_uri(Client *c, int count);
 gboolean hints_parse_prompt(const char *prompt, char *mode, gboolean *is_gmode);
+gboolean hints_is_gmode(void);
 void hints_clear(Client *c);
 void hints_focus_next(Client *c, const gboolean back);
 

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #include <webkit/webkit.h>
 #include <libintl.h>
-
+#include "hints.h"
 #include "../version.h"
 #include "ascii.h"
 #include "command.h"
@@ -464,7 +464,19 @@ gboolean vb_load_uri(Client *c, const Arg *arg)
         spawn_new_instance(uri);
 #else
         /* Open in a new tab */
-        Client *newclient = vb_tab_new(c, uri);
+        Client *newclient = vb_tab_new(c, uri, TRUE);
+        if (newclient) {
+            webkit_web_view_load_uri(newclient->webview, uri);
+            set_title(newclient, uri);
+        }
+#endif
+    } else if (arg->i == TARGET_TAB_BG) {
+#ifdef FEATURE_NO_TABS
+        /* With no-tabs feature, spawn a new browser instance instead */
+        spawn_new_instance(uri);
+#else
+        /* Open in a new tab in the background (don't activate) */
+        Client *newclient = vb_tab_new(c, uri, FALSE);
         if (newclient) {
             webkit_web_view_load_uri(newclient->webview, uri);
             set_title(newclient, uri);
@@ -886,7 +898,7 @@ __attribute__((used)) static void client_destroy(Client *c)
 static Client *client_new(WebKitWebView *webview)
 {
     /* Use the new tab-based client creation */
-    return vb_tab_new(NULL, NULL);
+    return vb_tab_new(NULL, NULL, TRUE);
 }
 
 /**
@@ -1589,12 +1601,25 @@ static void decide_navigation_action(Client *c, WebKitPolicyDecision *dec)
 
     /* Open in new tab if the open_in_new_tab state is set (from ;t hinting) */
     if (c->state.open_in_new_tab) {
-        /* Clear the flag after the first use. */
-        c->state.open_in_new_tab = FALSE;
+        gboolean bg = c->state.open_in_background;
+        /* Only clear the flags after the first use when NOT in g-mode
+         * (extended) hinting. In g-mode the hinting session continues after a
+         * fire, and every further hinted element must also open in a
+         * (background) tab. Clearing the flags here would make later fires
+         * navigate the current page instead. */
+        if (!hints_is_gmode()) {
+            /* Clear the flags after the first use. */
+            c->state.open_in_new_tab = FALSE;
+            c->state.open_in_background = FALSE;
+        }
 
         webkit_policy_decision_ignore(dec);
-        /* Open in a new tab */
-        vb_load_uri(c, &(Arg){TARGET_TAB, (char *)uri});
+        /* Open in a new tab (background if open_in_background is set, e.g. g; hinting) */
+        if (bg) {
+            vb_load_uri(c, &(Arg){TARGET_TAB_BG, (char *)uri});
+        } else {
+            vb_load_uri(c, &(Arg){TARGET_TAB, (char *)uri});
+        }
     }
     /* Spawn new instance if the new win flag is set on the mode, or the
      * navigation was triggered by CTRL-LeftMouse or MiddleMouse. */
@@ -1703,14 +1728,16 @@ static void on_webview_load_changed(WebKitWebView *webview,
             if (uri) {
                 set_title(c, uri);
             }
-            /* Make sure hinting is cleared before the new page is loaded.
-             * Without that vimb would still be in hinting mode after hinting
-             * was started and some links was clicked my mouse. Even if there
-             * could not hints be shown.
-             * Also leave input mode. Otherwise, hitting enter in an input box
-             * on a search engine page will take you to a results page in input
-             * mode. */
-            if (c->mode->flags & FLAG_HINTING || c->mode->id == 'i') {
+            /* Clear hinting before the new page is loaded, unless this is a
+             * g-mode (extended) hint fire redirected to a background tab.
+             * Without this, vimb would still be in hinting mode after hinting
+             * was started and a link was clicked by mouse. Also leave input
+             * mode — hitting Enter in a search-engine input box would leave
+             * input mode set on the results page. In g-mode hinting, the hint
+             * fires and redirects to a background tab, but we must keep the
+             * hinting session so further elements can be selected. */
+            if ((c->mode->flags & FLAG_HINTING && !hints_is_gmode())
+                    || c->mode->id == 'i') {
                 vb_enter(c, 'n');
             }
             break;
@@ -2451,7 +2478,7 @@ static void update_tab_label(Client *c)
  * @uri:     URI to load in the new tab (can be NULL).
  * @return:  The new client or NULL on error.
  */
-Client *vb_tab_new(Client *related, const char *uri)
+Client *vb_tab_new(Client *related, const char *uri, gboolean active)
 {
     Client *c;
     GtkWidget *tab_label;
@@ -2538,8 +2565,16 @@ Client *vb_tab_new(Client *related, const char *uri)
     ex_run_file(c, vb.files[FILES_CONFIG]);
 
     /* Switch to the new tab and focus its webview */
-    gtk_notebook_set_current_page(GTK_NOTEBOOK(vb.notebook), page_num);
-    gtk_widget_grab_focus(GTK_WIDGET(c->webview));
+    if (active) {
+        gtk_notebook_set_current_page(GTK_NOTEBOOK(vb.notebook), page_num);
+        gtk_widget_grab_focus(GTK_WIDGET(c->webview));
+    } else if (related) {
+        /* Background tab created for extended hint mode (g;...). The new
+         * webview and its load must not steal keyboard focus, otherwise the
+         * hinting client stops receiving the keys needed to filter hints.
+         * Re-grab focus on the related (hinting) client's input box. */
+        gtk_widget_grab_focus(GTK_WIDGET(related->input));
+    }
 
     return c;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -73,7 +73,7 @@
 #define FILE_CLOSED  "closed"
 #define FILE_COOKIES "cookies"
 
-enum { TARGET_CURRENT, TARGET_RELATED, TARGET_NEW, TARGET_TAB };
+enum { TARGET_CURRENT, TARGET_RELATED, TARGET_NEW, TARGET_TAB, TARGET_TAB_BG };
 
 typedef enum {
     RESULT_COMPLETE, RESULT_MORE, RESULT_ERROR
@@ -171,6 +171,7 @@ struct State {
     gboolean            processed_key;      /* indicates if a key press was handled and should not bubbled up */
     gboolean            ctrlv;              /* indicates if the CTRL-V temorary submode is on */
     gboolean            open_in_new_tab;    /* next navigation should open in new tab (for ;t hinting) */
+    gboolean            open_in_background;  /* open_in_new_tab target should NOT activate the new tab (for g; hinting) */
 
 #define PROMPT_SIZE 4
     char                prompt[PROMPT_SIZE];/* current prompt ':', 'g;t', '/' including nul */
@@ -343,7 +344,7 @@ void vb_statusbar_show_hover_url(Client *c, VbLinkType type, const char *uri);
 void vb_gui_style_update(Client *c, const char *name, const char *value);
 
 /* Tab management functions */
-Client *vb_tab_new(Client *related, const char *uri);
+Client *vb_tab_new(Client *related, const char *uri, gboolean active);
 void vb_tab_close(Client *c);
 void vb_tab_next(void);
 void vb_tab_prev(void);

--- a/src/scripts/hints.js
+++ b/src/scripts/hints.js
@@ -370,6 +370,18 @@ var hints = Object.freeze((function(){
         if (config.keepOpen) {
             /* reset the hint-keys filter */
             filterKeys = "";
+
+            /* Unfocus the just-fired hint and clear the active marker so the
+             * element is not left stuck in the highlighted (focus) state. This
+             * lets the user keep selecting further elements in extended (g-)
+             * hint mode without a stale green highlight. show(false) then
+             * focuses the first hint as a fresh starting point. */
+            if (activeHint) {
+                activeHint.unfocus();
+                mouseEvent(activeHint.e, "mouseout");
+            }
+            activeHint = undefined;
+
             show(false);
         } else {
             clear(true);


### PR DESCRIPTION
In extended hint mode (g;t, g;o, g;I), each selected hint now opens the link in a new background tab without stealing focus from the current page. This lets the user continue selecting hints without being redirected.

Previously:
- g;t fired each hint immediately and ACTIVATED the new tab (focus lost)
- g;o navigated the current tab away on each selection (page lost)
- g;I (image in new tab) also activated and stole focus

Changes:
- vb_tab_new: add 'active' boolean param; when FALSE, skip gtk_notebook_set_current_page + grab_focus so the new tab is created in the background. All existing callers pass TRUE.
- TARGET_TAB_BG: new Arg target enum value; handled in vb_load_uri identically to TARGET_TAB but calls vb_tab_new(..., FALSE).
- Client.state.open_in_background: new flag alongside open_in_new_tab; set by hints_create for g-mode 't'/'o', cleared by decide_navigation_action which then uses TARGET_TAB_BG.
- g;o in extended mode now sets open_in_new_tab so the link opens in a new tab (background) instead of navigating the current page.
- g;I: hint_function_check_result uses TARGET_TAB_BG directly (bypasses the flag pipeline since it does not go through decide_navigation_action).

Regular ;t and ;o non-g hinting is unchanged: ;t still activates the new tab, ;o still navigates the current tab.

closes #714