### PR TITLE
Fix segfault on opening or closing a tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   so closing the current tab first freed the client before the write.
   Also fixed a secondary use-after-free in the command-line activation handler
 * Fix `g;{mode}` extended hinting opens links in background tabs
+* Fixed segfault when opening a new tab via `window.open()` / `target="_blank"`
 
 ## [4.0.0]
 ### Added

--- a/src/main.c
+++ b/src/main.c
@@ -483,7 +483,7 @@ gboolean vb_load_uri(Client *c, const Arg *arg)
         }
 #endif
     } else { /* TARGET_RELATED */
-        Client *newclient = client_new(c->webview);
+        Client *newclient = vb_tab_new(c, NULL, TRUE);
         /* Load the uri into the new client. */
         webkit_web_view_load_uri(newclient->webview, uri);
         set_title(c, uri);
@@ -1544,7 +1544,7 @@ static WebKitWebView *on_webview_create(WebKitWebView *webview,
 
     return NULL;
 #else
-    Client *new = client_new(webview);
+    Client *new = vb_tab_new(c, NULL, TRUE);
 
     return new->webview;
 #endif
@@ -2632,6 +2632,10 @@ void vb_tab_close(Client *c)
     if (c->state.title) {
         g_free(c->state.title);
     }
+    if (c->state.input_timer) {
+        g_source_remove(c->state.input_timer);
+        c->state.input_timer = 0;
+    }
     completion_cleanup(c);
     map_cleanup(c);
     register_cleanup(c);
@@ -2847,7 +2851,6 @@ static WebKitWebView *webview_new(Client *c, WebKitWebView *webview)
     ucm = webkit_user_content_manager_new();
     if (webview) {
         new = WEBKIT_WEB_VIEW(g_object_new(WEBKIT_TYPE_WEB_VIEW,
-                    "network-session", vb.session,
                     "user-content-manager", ucm,
                     "related-view", webview,
                     NULL));

--- a/src/map.c
+++ b/src/map.c
@@ -118,6 +118,10 @@ void map_init(Client *c)
 
 void map_cleanup(Client *c)
 {
+    if (c->map.timout_id) {
+        g_source_remove(c->map.timout_id);
+        c->map.timout_id = 0;
+    }
     if (c->map.list) {
         g_slist_free_full(c->map.list, (GDestroyNotify)free_map);
     }


### PR DESCRIPTION
closes #801 #803

Culprit: two use-after-free bugs surfaced when opening a new tab and when closing a tab while a GLib timeout was still pending.

1) Opening a new tab via window.open()/target=_blank crashed.
   on_webview_create() created the new webview through client_new(), which
   ignored its argument and called vb_tab_new(NULL, ...). The new tab's
   WebKitWebView was therefore built WITHOUT the "related-view" property that
   WebKit requires for window.open()-spawned views. The returned webview was
   unrelated to the opener, which WebKit could not reconcile, and it crashed.
   Fix: pass the opener Client* so vb_tab_new() wires up related-view.

2) Closing a tab right after a keystroke crashed via a stale timeout.
   map_handle_keys() arms a 1s timeout (c->map.timout_id) after every
   keystroke to wait for multi-key mappings. When the tab was torn down
   (vb_tab_close) within that window, the pending timeout fired afterwards on
   the already-freed Client* -> read through a dangling pointer.
   Fix: map_cleanup() cancels the pending map timeout before freeing the map
   state; vb_tab_close() additionally cancels the pending input-message
   timeout for the same reason.

3) webview_new() set both "network-session" and "related-view" on related
   views. WebKit rejects setting network-session when related-view is given;
   the value is ignored and WebKit logs a CRITICAL on every new tab. Dropped
   the redundant network-session so the related view inherits its session from
   the opener.