### PR TITLE
Fix webkit_find_controller_search_finish CRITICAL on drag/navigate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Also fixed a secondary use-after-free in the command-line activation handler
 * Fix `g;{mode}` extended hinting opens links in background tabs
 * Fixed segfault when opening a new tab via `window.open()` / `target="_blank"`
+* Fixed spurious `webkit_find_controller_search_finish` CRITICAL assertion when
+  dragging elements or navigating while no search was active. The call is now
+  skipped unless a search is actually in progress.
 
 ## [4.0.0]
 ### Added

--- a/src/command.c
+++ b/src/command.c
@@ -60,7 +60,9 @@ gboolean command_search(Client *c, const Arg *arg, bool commit)
     g_assert(arg);
 
     if (arg->i == 0) {
-        webkit_find_controller_search_finish(c->finder);
+        if (c->state.search.active) {
+            webkit_find_controller_search_finish(c->finder);
+        }
 
         /* Clear the input only if the search is active and commit flag is
          * set. This allows us to stop searching with and without cleaning


### PR DESCRIPTION
command_search() was calling webkit_find_controller_search_finish() unconditionally whenever arg->i == 0, including on every WEBKIT_LOAD_COMMITTED event (via on_webview_load_changed) regardless of whether a search was active.

When a drag causes the web process to abort, WebKit fires WEBKIT_LOAD_COMMITTED and the find controller is no longer valid at that point, triggering the assertion:

  webkit_find_controller_search_finish: assertion
  'WEBKIT_IS_FIND_CONTROLLER(findController)' failed

Guard the call so webkit_find_controller_search_finish() is only invoked when c->state.search.active is true. The existing inputbox-clear block below already had this same guard; this aligns the search_finish call to match.

The gtk_drop_target_async_handle_event assertions and the process abort that follow are a WebKitGTK/GTK4 upstream DnD bug outside vimb's control.

closes #823 